### PR TITLE
core: add time related macros

### DIFF
--- a/cores/arduino/Arduino.h
+++ b/cores/arduino/Arduino.h
@@ -113,6 +113,7 @@ int digitalPinToInterrupt(pin_size_t pin);
 #include <zephyrSerial.h>
 #include <strings.h>
 #include <api/itoa.h>
+#include <time_macros.h>
 
 // Allow namespace-less operations if Arduino.h is included
 using namespace arduino;

--- a/cores/arduino/time_macros.h
+++ b/cores/arduino/time_macros.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <zephyr/sys/time_units.h>
+
+#define clockCyclesPerMicrosecond()  (1000000 / k_cyc_to_ns_near64(1000))
+#define clockCyclesToMicroseconds(a) (a / clockCyclesPerMicrosecond())
+#define microsecondsToClockCycles(a) (a * clockCyclesPerMicrosecond())


### PR DESCRIPTION
Fixes compilation error found at https://www.cnx-software.com/2024/12/10/arduino-core-for-zephyr-beta-released/