### PR TITLE
Implement SetClock Function

### DIFF
--- a/libraries/Wire/Wire.cpp
+++ b/libraries/Wire/Wire.cpp
@@ -21,7 +21,28 @@ void arduino::ZephyrI2C::begin(uint8_t slaveAddr) {
 
 void arduino::ZephyrI2C::end() {}
 
-void arduino::ZephyrI2C::setClock(uint32_t freq) {}
+void arduino::ZephyrI2C::setClock(uint32_t freq) {
+    uint8_t speed = 	I2C_SPEED_STANDARD;
+	if(freq >  0x06u ) {
+		if(freq == 100000) {
+		  speed = I2C_SPEED_STANDARD;
+		} else if(freq == 400000) {
+		  speed = I2C_SPEED_FAST;
+		} else if(freq == 1000000) {
+		  speed = I2C_SPEED_FAST_PLUS;
+		} else {
+		  speed = I2C_SPEED_STANDARD;
+		}
+	} else {
+		speed = (uint8_t) freq;
+	}
+	uint32_t i2c_cfg = I2C_MODE_CONTROLLER |
+					I2C_SPEED_SET(speed);
+
+	if (i2c_configure(i2c_dev, i2c_cfg)) {
+		//Serial.println("Failed to configure i2c interface.");
+	}
+}
 
 void arduino::ZephyrI2C::beginTransmission(uint8_t address) { // TODO for ADS1115
   _address = address;

--- a/loader/llext_exports.c
+++ b/loader/llext_exports.c
@@ -152,3 +152,4 @@ FORCE_EXPORT_SYM(__aeabi_dcmpeq);
 FORCE_EXPORT_SYM(__aeabi_d2iz);
 FORCE_EXPORT_SYM(__aeabi_f2d);
 FORCE_EXPORT_SYM(__aeabi_idivmod);
+FORCE_EXPORT_SYM(__aeabi_ldivmod);


### PR DESCRIPTION
Implemented I2C setClock funtion.  

```
void arduino::ZephyrI2C::setClock(uint32_t freq) {
    uint8_t speed = 	I2C_SPEED_STANDARD;
	if(freq >  0x06u ) {
		if(freq == 100000) {
		  speed = I2C_SPEED_STANDARD;
		} else if(freq == 400000) {
		  speed = I2C_SPEED_FAST;
		} else if(freq == 1000000) {
		  speed = I2C_SPEED_FAST_PLUS;
		} else {
		  speed = I2C_SPEED_STANDARD;
		}
	} else {
		speed = (uint8_t) freq;
	}
	uint32_t i2c_cfg = I2C_MODE_CONTROLLER |
					I2C_SPEED_SET(speed);

	if (i2c_configure(i2c_dev, i2c_cfg)) {
		//Serial.println("Failed to configure i2c interface.");
	}
}
```

frequency can be 100000, 400000 or I2C_SPEED_STANDARD or I2C_SPEED_FAST, while I2C_SPEED_FAST_PLUS is there (like in mbed) does not seem to register right now so only 100khz and 400khz are supported.

See https://github.com/arduino/ArduinoCore-zephyr/issues/23#issuecomment-2577843907