### PR TITLE
Implement analogReadResolution

### DIFF
--- a/cores/arduino/Arduino.h
+++ b/cores/arduino/Arduino.h
@@ -101,6 +101,9 @@ enum digitalPins {
 enum analogPins { DT_FOREACH_PROP_ELEM(DT_PATH(zephyr_user),
 				       adc_pin_gpios, AN_ENUMS) };
 
+// We provide analogReadResolution APIs
+void analogReadResolution(int bits);
+
 #endif
 
 #ifdef CONFIG_DAC

--- a/loader/boards/arduino_giga_r1_m7.overlay
+++ b/loader/boards/arduino_giga_r1_m7.overlay
@@ -206,70 +206,70 @@
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
-		zephyr,resolution = <12>;
+		zephyr,resolution = <16>;
 	};
 	channel@8 {
 		reg = <8>;
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
-		zephyr,resolution = <12>;
+		zephyr,resolution = <16>;
 	};
 	channel@9 {
 		reg = <9>;
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
-		zephyr,resolution = <12>;
+		zephyr,resolution = <16>;
 	};
 	channel@5 {
 		reg = <5>;
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
-		zephyr,resolution = <12>;
+		zephyr,resolution = <16>;
 	};
 	channel@d {
 		reg = <13>;
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
-		zephyr,resolution = <12>;
+		zephyr,resolution = <16>;
 	};
 	channel@c {
 		reg = <12>;
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
-		zephyr,resolution = <12>;
+		zephyr,resolution = <16>;
 	};
 	channel@a {
 		reg = <10>;
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
-		zephyr,resolution = <12>;
+		zephyr,resolution = <16>;
 	};
 	channel@10 {
 		reg = <16>;
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
-		zephyr,resolution = <12>;
+		zephyr,resolution = <16>;
 	};
 	channel@12 {
 		reg = <18>;
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
-		zephyr,resolution = <12>;
+		zephyr,resolution = <16>;
 	};
 	channel@13 {
 		reg = <19>;
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
-		zephyr,resolution = <12>;
+		zephyr,resolution = <16>;
 	};
 	/* PA0_C and PA1_C */
 	channel@0 {
@@ -277,14 +277,14 @@
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
-		zephyr,resolution = <12>;
+		zephyr,resolution = <16>;
 	};
 	channel@1 {
 		reg = <1>;
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
-		zephyr,resolution = <12>;
+		zephyr,resolution = <16>;
 	};
 };
 
@@ -304,14 +304,14 @@
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
-		zephyr,resolution = <12>;
+		zephyr,resolution = <16>;
 	};
 	channel@1 {
 		reg = <1>;
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
-		zephyr,resolution = <12>;
+		zephyr,resolution = <16>;
 	};
 };
 


### PR DESCRIPTION
resolves #36 

The current released version was always reading with 12 bits of resolution. The Arduino analogRead web page said that by default it should default to 10 bits.

The updated code is now ignoring the arduino_adc[idx].resolution field as this is setup for 12 and you can not change it run time.

Like the MBED version,  this version is using the static variable read_resolution to hold the current resolution.  Which we then pass through to zephyr when we do the reads.

I also changed the parameter buf that we pass through to zephyr from in16_t to uint16_t as if you choose resolution of 16 bits it was returning negative values.