### PR TITLE
Fix micros() rollover

### DIFF
--- a/cores/arduino/zephyrCommon.cpp
+++ b/cores/arduino/zephyrCommon.cpp
@@ -271,7 +271,7 @@ void delay(unsigned long ms) { k_sleep(K_MSEC(ms)); }
 void delayMicroseconds(unsigned int us) { k_sleep(K_USEC(us)); }
 
 unsigned long micros(void) {
-  return k_cyc_to_us_floor32(k_cycle_get_32());
+  return k_cyc_to_us_floor32(k_cycle_get_64());
 }
 
 unsigned long millis(void) { return k_uptime_get_32(); }


### PR DESCRIPTION
Fixes #25 

It was getting the 32 bit value dividing by system clock speed and returning it, so it never fully went through the 32 bit value to properly rollover changed to retrieve the 64 bit value instead, which appears to work
```
unsigned long micros(void) {
  return k_cyc_to_us_floor32(k_cycle_get_64());
}
```
Output from example sketch from before, shows rollover now:
```
US: 4288826633 4289826702 1000069	MS: 4288826 4289826 1000
US: 4289826733 4290826802 1000069	MS: 4289826 4290826 1000
US: 4290826833 4291826902 1000069	MS: 4290826 4291826 1000
US: 4291826933 4292827002 1000069	MS: 4291826 4292827 1001
US: 4292827057 4293827102 1000045	MS: 4292827 4293827 1000
US: 4293827133 4294827202 1000069	MS: 4293827 4294827 1000
US: 4294827233 860006 1000069	MS: 4294827 4295827 1000
US: 860058 1860107 1000049	MS: 4295827 4296827 1000
US: 1860137 2860206 1000069	MS: 4296827 4297827 1000
US: 2860237 3860306 1000069	MS: 4297827 4298827 1000
US: 3860358 4860406 1000048	MS: 4298827 4299827 1000
```