### PR TITLE
update to get threads working

### DIFF
--- a/cores/arduino/CMakeLists.txt
+++ b/cores/arduino/CMakeLists.txt
@@ -19,6 +19,7 @@ zephyr_sources(api/String.cpp)
 
 if(DEFINED CONFIG_ARDUINO_ENTRY)
 zephyr_sources(main.cpp)
+zephyr_sources(threads.cpp)
 endif()
 
 endif()

--- a/cores/arduino/main.cpp
+++ b/cores/arduino/main.cpp
@@ -9,10 +9,19 @@
 #include <zephyr/llext/symbol.h>
 #endif
 
+#ifdef CONFIG_MULTITHREADING
+void start_static_threads();
+#endif
+
 int main(void) {
 #if (DT_NODE_HAS_PROP(DT_PATH(zephyr_user), cdc_acm) && CONFIG_USB_CDC_ACM)
   Serial.begin(115200);
 #endif
+
+#ifdef CONFIG_MULTITHREADING
+  start_static_threads();
+#endif
+
   setup();
 
   for (;;) {

--- a/cores/arduino/threads.cpp
+++ b/cores/arduino/threads.cpp
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2025 Arduino SA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "Arduino.h"
+
+#ifdef CONFIG_MULTITHREADING
+void start_static_threads() {
+    #define _FOREACH_STATIC_THREAD(thread_data) \
+        STRUCT_SECTION_FOREACH(_static_thread_data, thread_data)
+
+    _FOREACH_STATIC_THREAD(thread_data) {
+        k_thread_create(thread_data->init_thread, thread_data->init_stack, thread_data->init_stack_size, thread_data->init_entry,
+                        thread_data->init_p1, thread_data->init_p2, thread_data->init_p3, thread_data->init_prio,
+                        thread_data->init_options, thread_data->init_delay);
+        k_thread_name_set(thread_data->init_thread, thread_data->init_name);
+        thread_data->init_thread->init_data = thread_data;
+    }
+
+    /*
+    * Take a sched lock to prevent them from running
+    * until they are all started.
+    */
+    k_sched_lock();
+    _FOREACH_STATIC_THREAD(thread_data) {
+        k_thread_start(thread_data->init_thread);
+    }
+    k_sched_unlock();
+}
+#endif

--- a/loader/llext_exports.c
+++ b/loader/llext_exports.c
@@ -48,6 +48,8 @@ EXPORT_SYMBOL(isupper);
 EXPORT_SYMBOL(islower);
 EXPORT_SYMBOL(isxdigit);
 
+EXPORT_SYMBOL(k_sched_lock);
+EXPORT_SYMBOL(k_sched_unlock);
 
 #if defined(CONFIG_USB_DEVICE_STACK)
 EXPORT_SYMBOL(usb_enable);

--- a/variants/llext/linker_script.ld
+++ b/variants/llext/linker_script.ld
@@ -34,6 +34,10 @@ SECTIONS {
         KEEP (*(.ctors))
         KEEP (*(.dtors))
         KEEP (*(.fini))
+
+        __static_thread_data_list_start = .;
+        KEEP(*(SORT_BY_NAME(.__static_thread_data.static.*)));
+        __static_thread_data_list_end = .;
     }
 
     .rodata : {


### PR DESCRIPTION
@KurtE - @facchinm 

Changes made to:
llext_exports.c
main.cpp in core arduino directory
linker_script.ld

Details of changes are shown in https://github.com/arduino/ArduinoCore-zephyr/issues/37

Test sketches if you want to try:
[thread_test_sketches.zip](https://github.com/user-attachments/files/18519157/thread_test_sketches.zip)

EDIT: Just tried building for nano 33 sense ble and getting error
```
  /home/zephyr-sdk-0.16.8/arm-zephyr-eabi/bin/../lib/gcc/arm-zephyr-eabi/12.2.0/../../../../arm-zephyr-eabi/bin/ld.bfd: app/libapp.a(llext_exports.c.obj):(._llext_const_symbol.static.__llext_sym___cxa_pure_virtual_+0x4): undefined reference to `__cxa_pure_virtual'
collect2: error: ld returned 1 exit status
ninja: build stopped: subcommand failed.
FATAL ERROR: command exited with status 1: /usr/bin/cmake --build /home/my_new_zephyr_folder/ArduinoCore-zephyr/build
```
it is set up in exports.c as:
```
FORCE_EXPORT_SYM(__cxa_pure_virtual);
```
See https://github.com/arduino/ArduinoCore-zephyr/issues/44#issuecomment-2609901342.  Forgot to update conf files for other boards.
