### PR TITLE
Added legacy pin coverager for nano boards

### DIFF
--- a/variants/arduino_nano_33_ble/variant.h
+++ b/variants/arduino_nano_33_ble/variant.h
@@ -3,3 +3,11 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+// TODO: correctly handle these legacy defines
+#define MOSI    0
+#define MISO    0
+#define SCK     0
+#define SS      0
+#define SDA     0
+#define SCL     0

--- a/variants/arduino_nano_33_ble/variant.h
+++ b/variants/arduino_nano_33_ble/variant.h
@@ -5,9 +5,9 @@
  */
 
 // TODO: correctly handle these legacy defines
-#define MOSI    0
-#define MISO    0
-#define SCK     0
-#define SS      0
+#define MOSI    11
+#define MISO    12
+#define SCK     13
+#define SS      10
 #define SDA     0
 #define SCL     0

--- a/variants/arduino_nano_33_ble_sense/variant.h
+++ b/variants/arduino_nano_33_ble_sense/variant.h
@@ -3,3 +3,11 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+// TODO: correctly handle these legacy defines
+#define MOSI    0
+#define MISO    0
+#define SCK     0
+#define SS      0
+#define SDA     0
+#define SCL     0

--- a/variants/arduino_nano_33_ble_sense/variant.h
+++ b/variants/arduino_nano_33_ble_sense/variant.h
@@ -5,9 +5,9 @@
  */
 
 // TODO: correctly handle these legacy defines
-#define MOSI    0
-#define MISO    0
-#define SCK     0
-#define SS      0
+#define MOSI    11
+#define MISO    12
+#define SCK     13
+#define SS      10
 #define SDA     0
 #define SCL     0

--- a/variants/arduino_nano_33_iot/variant.h
+++ b/variants/arduino_nano_33_iot/variant.h
@@ -3,3 +3,11 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+// TODO: correctly handle these legacy defines
+#define MOSI    0
+#define MISO    0
+#define SCK     0
+#define SS      0
+#define SDA     0
+#define SCL     0

--- a/variants/arduino_nano_33_iot/variant.h
+++ b/variants/arduino_nano_33_iot/variant.h
@@ -5,9 +5,9 @@
  */
 
 // TODO: correctly handle these legacy defines
-#define MOSI    0
-#define MISO    0
-#define SCK     0
-#define SS      0
+#define MOSI    11
+#define MISO    12
+#define SCK     13
+#define SS      10
 #define SDA     0
 #define SCL     0


### PR DESCRIPTION
While playing with SDfat kept getting an error about ss pin not defined.  Then @KurtE reminded that on the teensy they are defined in the core.  Then remembered say that for the giga.  When I looked for the nano boards (variant.h) they were not covered.  This PR adds:
```
// TODO: correctly handle these legacy defines
#define MOSI    0
#define MISO    0
#define SCK     0
#define SS      0
#define SDA     0
#define SCL     0
```
to the nano variant.h files (ble, sense and iot).  

recompiled core and retested and the sdfat compile error disappeared.