### PR TITLE
Fix micros() for nano without breaking giga

### DIFF
--- a/cores/arduino/zephyrCommon.cpp
+++ b/cores/arduino/zephyrCommon.cpp
@@ -293,8 +293,12 @@ void delay(unsigned long ms) { k_sleep(K_MSEC(ms)); }
 void delayMicroseconds(unsigned int us) { k_sleep(K_USEC(us)); }
 
 unsigned long micros(void) {
+#ifdef CONFIG_TIMER_HAS_64BIT_CYCLE_COUNTER
   return k_cyc_to_us_floor32(k_cycle_get_64());
-}
+#else
+  return k_cyc_to_us_floor32(k_cycle_get_32());
+#endif
+ }
 
 unsigned long millis(void) { return k_uptime_get_32(); }
 


### PR DESCRIPTION
Fixes #60 

The rollover fix for the giga used the 64 bit timer instead of 32 bits.  The nano does not have a 64 bit timer, so you need to use the 32 bit instead.

So I know check to see if the processor supports 64 bits if so use it else fall back to 32 bit.

@mjs513 you might want to try this out to see if it fixes the issue for you