### PR TITLE
GIGA: Remove Arduino pins 11-13 from PWM list to fix SPI1

### DIFF
--- a/loader/boards/arduino_giga_r1_m7.overlay
+++ b/loader/boards/arduino_giga_r1_m7.overlay
@@ -63,7 +63,7 @@
 
 	pwm1: pwm {
 		status = "okay";
-		pinctrl-0 = <&tim1_ch3_pj9 &tim1_ch1_pk1 &tim1_ch2_pj11>;
+		pinctrl-0 = <&tim1_ch3_pj9 &tim1_ch1_pk1>;
 		pinctrl-names = "default";
 	};
 };
@@ -107,21 +107,11 @@
 
 	pwm8: pwm {
 		status = "okay";
-		pinctrl-0 = <&tim8_ch1_pj8 &tim8_ch2_pj10>;
+		pinctrl-0 = <&tim8_ch1_pj8>;
 		pinctrl-names = "default";
 	};
 };
 
-&timers12 {
-	status = "okay";
-	st,prescaler = <100>;
-
-	pwm12: pwm {
-		status = "okay";
-		pinctrl-0 = <&tim12_ch1_ph6>;
-		pinctrl-names = "default";
-	};
-};
 
 &pwm1 {
 	/* Use the pwmclock node to start the clock generation */
@@ -518,10 +508,7 @@
 			   <&pwm3 1 PWM_HZ(500) PWM_POLARITY_NORMAL>,
 			   <&pwm4 3 PWM_HZ(500) PWM_POLARITY_NORMAL>,
 			   <&pwm4 4 PWM_HZ(500) PWM_POLARITY_NORMAL>,
-			   <&pwm1 1 PWM_HZ(5000) PWM_POLARITY_NORMAL>,
-			   <&pwm8 2 PWM_HZ(500) PWM_POLARITY_NORMAL>,
-			   <&pwm1 2 PWM_HZ(5000) PWM_POLARITY_NORMAL>,
-			   <&pwm12 1 PWM_HZ(500) PWM_POLARITY_NORMAL>;
+			   <&pwm1 1 PWM_HZ(5000) PWM_POLARITY_NORMAL>;
 
 		io-channels =	<&adc1 4>,
 				<&adc1 8>,

--- a/loader/boards/arduino_giga_r1_m7.overlay
+++ b/loader/boards/arduino_giga_r1_m7.overlay
@@ -63,6 +63,8 @@
 
 	pwm1: pwm {
 		status = "okay";
+		/* Temporarily removed SPI1 pins */
+		/* pinctrl-0 = <&tim1_ch3_pj9 &tim1_ch1_pk1 &tim1_ch2_pj11>; */
 		pinctrl-0 = <&tim1_ch3_pj9 &tim1_ch1_pk1>;
 		pinctrl-names = "default";
 	};
@@ -107,11 +109,23 @@
 
 	pwm8: pwm {
 		status = "okay";
+		/* Temporarily removed SPI1 pins */
+		/* pinctrl-0 = <&tim8_ch1_pj8 &tim8_ch2_pj10>; */
 		pinctrl-0 = <&tim8_ch1_pj8>;
 		pinctrl-names = "default";
 	};
 };
 
+/* Temporarily removed SPI1 pins */
+/* &timers12 { */
+/*	status = "okay"; */
+/* 	st,prescaler = <100>; */
+/*	pwm12: pwm { */
+/* 		status = "okay"; */
+/* 		pinctrl-0 = <&tim12_ch1_ph6>; */
+/* 		pinctrl-names = "default"; */
+/* 	}; */
+/*}; */
 
 &pwm1 {
 	/* Use the pwmclock node to start the clock generation */
@@ -508,7 +522,12 @@
 			   <&pwm3 1 PWM_HZ(500) PWM_POLARITY_NORMAL>,
 			   <&pwm4 3 PWM_HZ(500) PWM_POLARITY_NORMAL>,
 			   <&pwm4 4 PWM_HZ(500) PWM_POLARITY_NORMAL>,
-			   <&pwm1 1 PWM_HZ(5000) PWM_POLARITY_NORMAL>;
+				/* Temporarily removed SPI1 pins */
+			   /* <&pwm1 1 PWM_HZ(5000) PWM_POLARITY_NORMAL>, */
+			   /* <&pwm8 2 PWM_HZ(500) PWM_POLARITY_NORMAL>, */
+			   /* <&pwm1 2 PWM_HZ(5000) PWM_POLARITY_NORMAL>, */
+			   /* <&pwm12 1 PWM_HZ(500) PWM_POLARITY_NORMAL>; */
+   			   <&pwm1 1 PWM_HZ(5000) PWM_POLARITY_NORMAL>;
 
 		io-channels =	<&adc1 4>,
 				<&adc1 8>,


### PR DESCRIPTION
resolves: [#64](https://github.com/arduino/ArduinoCore-zephyr/issues/64)

Removed the pins logical Arduino pins 11-13 from the PWM pin list, plus their defines
for the timers.

With these defines in place, the pins Alternate Function settings were set to that of the timers
versus the SPI value (5)

Note: This was done by [@mjs513](https://github.com/mjs513) and myself.