### PR TITLE
Nano 33 BLE - enable the SPI1 sensors

### DIFF
--- a/cores/arduino/main.cpp
+++ b/cores/arduino/main.cpp
@@ -13,33 +13,24 @@
 void start_static_threads();
 #endif
 
-#ifdef CONFIG_GPIO_NRFX
-#include <zephyr/dt-bindings/gpio/nordic-nrf-gpio.h>
-#endif
+
+// This function will be overwriten by most variants.
+void __attribute__((weak))initVariant(void) {
+
+}
+
 
 int main(void) {
 #if (DT_NODE_HAS_PROP(DT_PATH(zephyr_user), cdc_acm) && CONFIG_USB_CDC_ACM)
   Serial.begin(115200);
 #endif
 
+  initVariant();
+
 #ifdef CONFIG_MULTITHREADING
   start_static_threads();
 #endif
 
-#ifdef CONFIG_GPIO_NRFX
-  static const struct gpio_dt_spec enable_sensors =
-    GPIO_DT_SPEC_GET(DT_PATH(zephyr_user), pin_enable_gpios);
-  if (gpio_is_ready_dt(&enable_sensors)) {
-      gpio_flags_t flags = enable_sensors.dt_flags | GPIO_OUTPUT_HIGH | GPIO_ACTIVE_HIGH | NRF_GPIO_DRIVE_H0H1;
-      Serial.println((uint32_t)flags, HEX);
-      
-      gpio_pin_configure(enable_sensors.port, enable_sensors.pin, flags);
-      gpio_pin_set(enable_sensors.port, enable_sensors.pin, HIGH);
-      //Serial.println("### Sensor pin enabled ###");
-
-      delay(500);
-  }
-#endif
   setup();
 
   for (;;) {

--- a/cores/arduino/main.cpp
+++ b/cores/arduino/main.cpp
@@ -13,6 +13,10 @@
 void start_static_threads();
 #endif
 
+#ifdef CONFIG_GPIO_NRFX
+#include <zephyr/dt-bindings/gpio/nordic-nrf-gpio.h>
+#endif
+
 int main(void) {
 #if (DT_NODE_HAS_PROP(DT_PATH(zephyr_user), cdc_acm) && CONFIG_USB_CDC_ACM)
   Serial.begin(115200);
@@ -22,6 +26,20 @@ int main(void) {
   start_static_threads();
 #endif
 
+#ifdef CONFIG_GPIO_NRFX
+  static const struct gpio_dt_spec enable_sensors =
+    GPIO_DT_SPEC_GET(DT_PATH(zephyr_user), pin_enable_gpios);
+  if (gpio_is_ready_dt(&enable_sensors)) {
+      gpio_flags_t flags = enable_sensors.dt_flags | GPIO_OUTPUT_HIGH | GPIO_ACTIVE_HIGH | NRF_GPIO_DRIVE_H0H1;
+      Serial.println((uint32_t)flags, HEX);
+      
+      gpio_pin_configure(enable_sensors.port, enable_sensors.pin, flags);
+      gpio_pin_set(enable_sensors.port, enable_sensors.pin, HIGH);
+      //Serial.println("### Sensor pin enabled ###");
+
+      delay(500);
+  }
+#endif
   setup();
 
   for (;;) {

--- a/loader/boards/arduino_nano_33_ble_sense.overlay
+++ b/loader/boards/arduino_nano_33_ble_sense.overlay
@@ -45,6 +45,8 @@
 
 / {
 	zephyr,user {
+		pin-enable-gpios = <&gpio0 22 GPIO_ACTIVE_HIGH>;
+
 		digital-pin-gpios = <&arduino_nano_header 0 0>,
 				    <&arduino_nano_header 1 0>,
 				    <&arduino_nano_header 2 0>,

--- a/variants/arduino_nano_33_ble_sense/variant.cpp
+++ b/variants/arduino_nano_33_ble_sense/variant.cpp
@@ -1,6 +1,23 @@
+#include "Arduino.h"
 #include <hal/nrf_power.h>
+#include <zephyr/dt-bindings/gpio/nordic-nrf-gpio.h>
 
 void _on_1200_bps() {
     nrf_power_gpregret_set(NRF_POWER, 0, 0xb0);
     NVIC_SystemReset();
+}
+
+void initVariant(void) {
+  static const struct gpio_dt_spec enable_sensors =
+    GPIO_DT_SPEC_GET(DT_PATH(zephyr_user), pin_enable_gpios);
+  if (gpio_is_ready_dt(&enable_sensors)) {
+      gpio_flags_t flags = enable_sensors.dt_flags | GPIO_OUTPUT_HIGH | GPIO_ACTIVE_HIGH | NRF_GPIO_DRIVE_H0H1;
+      Serial.println((uint32_t)flags, HEX);
+      
+      gpio_pin_configure(enable_sensors.port, enable_sensors.pin, flags);
+      gpio_pin_set(enable_sensors.port, enable_sensors.pin, HIGH);
+      //Serial.println("### Sensor pin enabled ###");
+
+      delay(500);
+  }
 }


### PR DESCRIPTION
Resolves: #51

There is an IO pin on the NANO that that when turned on, enables most of the sensors on the BLE sense which are on SPI1.   The MBED version, enables this pin as part of the main().

Which I am trying to emulate.  There is code already in, that if you use at least one of the zephyr device drivers, will eanble this pin.  However that does not help when you are using external libraries or the like.

So I added details about this pin in our overlay file, in the zephyr,user section.

I then added code to main.cpp, that is only included if your are building using an NRFX board.  Currently the nano and one of the nicla boards.  Could also specically only do this on the NANO, but probably does not matter as, the code tries to find that property and only if it is found, does it turn on the pin.

Note: The MBED version turn on this pin with high drive.  Which I emulated using the information, mentioned in the zephyr discussion.
https://github.com/zephyrproject-rtos/zephyr/discussions/78710 In one of my sketches I verified that the pin pads configuration looks the same as mbed setup.

With these changes I am able to access most of the sensors. Most of the testing has been done by @mjs513, with some by myself as well.