### PR TITLE
update to llext_exports.c

### DIFF
--- a/loader/llext_exports.c
+++ b/loader/llext_exports.c
@@ -48,6 +48,8 @@ EXPORT_SYMBOL(isupper);
 EXPORT_SYMBOL(islower);
 EXPORT_SYMBOL(isxdigit);
 
+EXPORT_SYMBOL(atan2);
+
 EXPORT_SYMBOL(k_sched_lock);
 EXPORT_SYMBOL(k_sched_unlock);
 


### PR DESCRIPTION
Added atan2 to llext_exports.c to resolve issues with the BMI270 api that I have seen on the Nano and Giga.  Probably for all boards that use the BMI270.

See issue:
[Portenta H7 Lite: Std lib atan2 causes a Undefined in Symbol Table #73](https://github.com/arduino/ArduinoCore-zephyr/issues/73)

[Nano 33 and Giga: BMI270/BMM150 Compiles but Looses Com Port after Upload #69](https://github.com/arduino/ArduinoCore-zephyr/issues/69)

Didn't rebuild for this PR figured workflow.  If you want I can.  Been just updating firmware and variants for this change.  Unfortunately I have already incorporated @KurtE's changes for the H7