### PR TITLE
bootstrap / build.sh cleanups

### DIFF
--- a/.github/workflows/package_core.yml
+++ b/.github/workflows/package_core.yml
@@ -17,20 +17,18 @@ jobs:
       CORE_ARTIFACT: ${{ env.CORE_ARTIFACT }}
       BOARD_VARIANTS: ${{ env.BOARD_VARIANTS }}
     steps:
-      - name: Install toolchain
+      - name: Install OS dependencies
         working-directory: /opt
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends git cmake wget python3-pip ninja-build ccache
-          wget -nv https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.8/zephyr-sdk-0.16.8_linux-x86_64_minimal.tar.xz
-          tar xf zephyr-sdk-0.16.8_linux-x86_64_minimal.tar.xz && cd zephyr-sdk-0.16.8 && ./setup.sh -t arm-zephyr-eabi -c
 
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Initialize
+      - name: Initialize Zephyr environment
         run: |
           ./extra/bootstrap.sh -o=--filter=tree:0
           echo "CORE_TAG=$(git describe --always)" >> "$GITHUB_ENV"

--- a/README.md
+++ b/README.md
@@ -118,11 +118,13 @@ sudo apt install python3-pip python3-setuptools python3-venv build-essential git
 cd ArduinoCore-zephyr
 ./extra/bootstrap.sh
 ```
-### Install the Zephyr SDK
-Download and install the Zephyr SDK for your OS from [here](https://github.com/zephyrproject-rtos/sdk-ng/releases/tag/v0.16.8).
 
-> [!NOTE]  
-> This core is validated for version v0.16.8. Compatibility with later versions has not been tested yet.
+This will take care of installing `west`, the Zephyr build tool. It will then
+download all packages required for a Zephyr build in addition to the toolchains
+in the Zephyr SDK.
+
+> [!NOTE]
+> This core is validated with version v0.17.0. Compatibility with later versions has not been tested yet.
 
 ### Build the Loader
 

--- a/README.md
+++ b/README.md
@@ -133,12 +133,13 @@ The target can be specified either with the Arduino board name (as defined in
 boards.txt), or with the Zephyr board name and any additional arguments that
 may be required by the Zephyr build system.
 
-For example, to build for the Arduino Portenta H7, you can run either:
+For example, to build for the Arduino Portenta H7, you can use either the
+Arduino name:
 ```bash
 ./extra/build.sh portentah7
 ```
 
-or:
+or the Zephyr board target:
 
 ```bash
 ./extra/build.sh arduino_portenta_h7//m7

--- a/README.md
+++ b/README.md
@@ -126,19 +126,24 @@ Download and install the Zephyr SDK for your OS from [here](https://github.com/z
 
 ### Build the Loader
 
-To build the loader, run the following commands:
-```bash
-export ZEPHYR_SDK_INSTALL_DIR=$folder_where_you_installed_the_sdk
-./extra/build.sh $zephyr_board_name $arduino_variant_board_name
-```
-Replace `$zephyr_board_name` and `$arduino_variant_board_name` with the appropriate names for your board.
+The loader is compiled for each board by running the `./extra/build.sh` script.
+The target can be specified either with the Arduino board name (as defined in
+boards.txt), or with the Zephyr board name and any additional arguments that
+may be required by the Zephyr build system.
 
-Example for Arduino Portenta H7:
+For example, to build for the Arduino Portenta H7, you can run either:
 ```bash
-./extra/build.sh arduino_portenta_h7//m7 arduino_portenta_h7
+./extra/build.sh portentah7
 ```
 
-The firmwares will be copied to [firmwares](/firmwares) folder.
+or:
+
+```bash
+./extra/build.sh arduino_portenta_h7//m7
+```
+
+The firmwares will be copied to [firmwares](/firmwares) folder, and the
+associated variant will be updated.
 
 ### Flash the Loader
 

--- a/extra/bootstrap.sh
+++ b/extra/bootstrap.sh
@@ -12,7 +12,7 @@ west init -l .
 west update "$@"
 west zephyr-export
 pip install -r ../zephyr/scripts/requirements-base.txt
-# download slim toolchain from https://github.com/zephyrproject-rtos/sdk-ng/releases/tag/v0.16.8
+west sdk install --version 0.17.0 -t arm-zephyr-eabi
 
 # add here the required blobs based on supported platforms
 west blobs fetch hal_nxp

--- a/extra/package_tool.sh
+++ b/extra/package_tool.sh
@@ -2,16 +2,17 @@
 
 set -e
 
-TOOL_NAME=$(basename $1)
-VERSION=$2
+TOOL_DIR=$(readlink -f ${1:-.})
+TOOL_NAME=$(basename $TOOL_DIR)
+VERSION=${2:-dev}
 
-BASE_DIR=$(readlink -f $(dirname $0)/..)
-TOOL_DIR="$BASE_DIR/extra/$TOOL_NAME"
-if ! [ -d "$TOOL_DIR" ] || [ -z "$VERSION" ] ; then
-	echo "Usage: $0 <tool_name> <version>"
+if ! [ -f "$TOOL_DIR/go.mod" ] ; then
+	echo "Not a valid tool directory: $TOOL_DIR"
+	echo "Usage: $0 [<tool_dir>] [<version>]"
 	exit 1
 fi
 
+BASE_DIR=$(readlink -f $(dirname $0)/..)
 DIR=${BASE_DIR}/distrib
 
 hash_file() {
@@ -71,5 +72,9 @@ build_for_arch "linux" "amd64" "x86_64-linux-gnu"
 build_for_arch "linux" "arm64" "aarch64-linux-gnu"
 build_for_arch "darwin" "amd64" "i386-apple-darwin11"
 build_for_arch "windows" "386" "i686-mingw32"
-build_json
-echo "Build completed for $TOOL_NAME $VERSION: $DIR/$TOOL_NAME-$VERSION.json"
+if [ "${VERSION}" == "dev" ] ; then
+	echo "Build completed for $TOOL_NAME $VERSION in $DIR"
+else
+	build_json
+	echo "Build completed for $TOOL_NAME $VERSION: $DIR/$TOOL_NAME-$VERSION.json"
+fi

--- a/extra/sync-zephyr-artifacts/README.md
+++ b/extra/sync-zephyr-artifacts/README.md
@@ -1,0 +1,26 @@
+## Sync Zephyr Artifacts tool
+
+This tool fetches the pre-built files that are associated with the current
+revision of the Arduino core for Zephyr. This makes it possible to use the
+repository as a local core with the Arduino IDE without the need to have the
+full Zephyr build system installed and configured.
+
+Pre-built files are generated only for the most recent commits in each branch.
+If in doubt, checkout the current version of the branch you are interested in
+before running the tool.
+
+### Getting the tool
+
+If you have installed the Arduino IDE and the Arduino core for Zephyr, you can
+find the pre-built files in the `.arduino15/packages/arduino/tools/` folder in
+your home directory. You can directly use the tool from there.
+
+### Building manually
+
+To build the tool, you need to have the Go programming language installed; make
+sure you have the `go` command available in your PATH. Then, use the `go build`
+command to build the tool for your platform.
+
+To build the full set of binaries for all platforms, run the `package_tool.sh`
+script in the parent directory with `../package_tool.sh`, or provide the path
+to this directory as an argument.

--- a/extra/zephyr-sketch-tool/README.md
+++ b/extra/zephyr-sketch-tool/README.md
@@ -1,0 +1,26 @@
+## Zephyr Sketch Tool
+
+This tool converts various binary files into a format that can be used
+by the Zephyr loader.
+
+The loader expects to find a specific header in a fixed location in the binary
+file, with information about the sketch and the build options chosen by the
+user. The location of the header was selected so that it affects unused bytes
+in the ELF file format; when dealing with binary files, 16 bytes are added at
+the beginning to reserve space for the header.
+
+### Getting the tool
+
+If you have installed the Arduino IDE and the Arduino core for Zephyr, you can
+find the pre-built files in the `.arduino15/packages/arduino/tools/` folder in
+your home directory. You can directly use the tool from there.
+
+### Building manually
+
+To build the tool, you need to have the Go programming language installed; make
+sure you have the `go` command available in your PATH. Then, use the `go build`
+command to build the tool for your platform.
+
+To build the full set of binaries for all platforms, run the `package_tool.sh`
+script in the parent directory with `../package_tool.sh`, or provide the path
+to this directory as an argument.


### PR DESCRIPTION
* Make `bootstrap.sh` install the Zephyr SDK automatically
* Make `build.sh` take at least one argument, print list of targets if no argument or `-h`/`--help` given
* Document these changes in the `README.md` of the repo