### PR TITLE
If sketch is not connected to serial - dump serial output

### DIFF
--- a/cores/arduino/SerialUSB.h
+++ b/cores/arduino/SerialUSB.h
@@ -18,6 +18,8 @@ public:
 	void begin(unsigned long baudrate) { begin(baudrate, SERIAL_8N1); }
 
 	operator bool() override;
+	size_t write(const uint8_t *buffer, size_t size) override;
+	void flush() override;
 
 protected:
 	uint32_t dtr = 0;

--- a/cores/arduino/USB.cpp
+++ b/cores/arduino/USB.cpp
@@ -124,5 +124,16 @@ arduino::SerialUSB_::operator bool() {
     return dtr;
 }
 
+
+size_t  arduino::SerialUSB_::write(const uint8_t *buffer, size_t size) {
+    if (!Serial) return 0;
+    return arduino::ZephyrSerial::write(buffer, size);
+}
+
+void arduino::SerialUSB_::flush() {
+    if (!Serial) return;
+    arduino::ZephyrSerial::flush();
+}
+
 arduino::SerialUSB_ Serial(usb_dev);
 #endif


### PR DESCRIPTION
Should resolve #35 

Tested with Portenta, but should work on all of the others as well.

Current code would hang after a few Serial.print like statements happened when we are not connected to the Serial monitor.

So I put overrides in for the Serial.write(buf, cnt) and Serial.flush() That would first check to see if Serial returns true (DTR)...

This appears to match the behavior of the MBED Portenta H8 code.