### PR TITLE
zephyr: update to zephyr-arduino-20250520

### DIFF
--- a/.github/workflows/package_core.yml
+++ b/.github/workflows/package_core.yml
@@ -10,7 +10,6 @@ jobs:
     name: Build and package core
     runs-on: ubuntu-latest
     env:
-      ZEPHYR_SDK_INSTALL_DIR: /opt/zephyr-sdk-0.16.8
       CCACHE_IGNOREOPTIONS: -specs=*
     outputs:
       CORE_TAG: ${{ env.CORE_TAG }}

--- a/boards.txt
+++ b/boards.txt
@@ -13,7 +13,7 @@ giga.menu.debug.false.postbuild_debug=
 giga.menu.debug.true.postbuild_debug=-debug
 
 giga.build.zephyr_target=arduino_giga_r1//m7
-giga.build.zephyr_args=--shield giga_display_shield
+giga.build.zephyr_args=--shield arduino_giga_display_shield
 giga.build.variant=arduino_giga_r1_stm32h747xx_m7
 giga.build.mcu=cortex-m7
 giga.build.fpu=-mfpu=fpv5-d16

--- a/extra/build.sh
+++ b/extra/build.sh
@@ -2,6 +2,10 @@
 
 set -e
 
+source venv/bin/activate
+
+ZEPHYR_BASE=$(west topdir)/zephyr
+
 if [ x$ZEPHYR_SDK_INSTALL_DIR == x"" ]; then
 	SDK_PATH=$(west sdk list | grep path | tail -n 1 | cut -d ':' -f 2 | tr -d ' ')
 	if [ x$SDK_PATH == x ]; then
@@ -49,10 +53,6 @@ fi
 
 echo
 echo "Build target: $target $args"
-
-source venv/bin/activate
-
-ZEPHYR_BASE=$(west topdir)/zephyr
 
 # Get the variant name (NORMALIZED_BOARD_TARGET in Zephyr)
 variant=$(extra/get_variant_name.sh $target)

--- a/loader/llext_exports.c
+++ b/loader/llext_exports.c
@@ -112,7 +112,6 @@ FORCE_EXPORT_SYM(net_mgmt_NET_REQUEST_WIFI_AP_ENABLE);
 
 #if defined(CONFIG_BT)
 FORCE_EXPORT_SYM(bt_enable_raw);
-FORCE_EXPORT_SYM(bt_hci_raw_set_mode);
 FORCE_EXPORT_SYM(bt_send);
 FORCE_EXPORT_SYM(bt_buf_get_tx);
 FORCE_EXPORT_SYM(net_buf_simple_pull);

--- a/variants/arduino_giga_r1_stm32h747xx_m7/arduino_giga_r1_stm32h747xx_m7.overlay
+++ b/variants/arduino_giga_r1_stm32h747xx_m7/arduino_giga_r1_stm32h747xx_m7.overlay
@@ -148,24 +148,22 @@
 
 &dcmi {
 	status = "okay";
-	sensor = <&gc2145>;
 	/* ext-sdram = <&sdram1>; */
 	pinctrl-0 = <&dcmi_hsync_ph8 &dcmi_pixclk_pa6 &dcmi_vsync_pi5
 				&dcmi_d0_ph9 &dcmi_d1_ph10 &dcmi_d2_ph11 &dcmi_d3_pg11
 				&dcmi_d4_ph14 &dcmi_d5_pi4 &dcmi_d6_pi6 &dcmi_d7_pi7>;
 	pinctrl-names = "default";
-	bus-width = <8>;
-	hsync-active = <0>;
-	vsync-active = <0>;
-	pixelclk-active = <0>;
-	capture-rate = <1>;
 	dmas = <&dma1 0 75 (STM32_DMA_PERIPH_TO_MEMORY | STM32_DMA_PERIPH_NO_INC |
 			STM32_DMA_MEM_INC | STM32_DMA_PERIPH_32BITS | STM32_DMA_MEM_32BITS |
 			STM32_DMA_PRIORITY_HIGH) STM32_DMA_FIFO_1_4>;
 
 	port {
 		dcmi_ep_in: endpoint {
-			remote-endpoint = <&gc2145_ep_out>;
+			remote-endpoint-label = "gc2145_ep_out";
+			bus-width = <8>;
+			hsync-active = <0>;
+			vsync-active = <0>;
+			pclk-sample = <0>;
 		};
 	};
 };

--- a/variants/arduino_portenta_h7_stm32h747xx_m7/arduino_portenta_h7_stm32h747xx_m7.overlay
+++ b/variants/arduino_portenta_h7_stm32h747xx_m7/arduino_portenta_h7_stm32h747xx_m7.overlay
@@ -27,7 +27,7 @@
 
 		port {
 			gc2145_ep_out: endpoint {
-				remote-endpoint = <&dcmi_ep_in>;
+				remote-endpoint-label = "dcmi_ep_in";
 			};
 		};
 	};
@@ -41,7 +41,7 @@
 
 		port {
 			ov7670_ep_out: endpoint {
-				remote-endpoint = <&dcmi_ep_in>;
+				remote-endpoint-label = "dcmi_ep_in";
 			};
 		};
 	};
@@ -132,26 +132,23 @@
 
 &dcmi {
 	status = "okay";
-	sensor = <&gc2145>;
-	/* sensor = <&ov7670>; */
 	/* ext-sdram = <&sdram1>; */
 	pinctrl-0 = <&dcmi_hsync_pa4 &dcmi_pixclk_pa6 &dcmi_vsync_pi5
 		     &dcmi_d0_ph9 &dcmi_d1_ph10 &dcmi_d2_ph11 &dcmi_d3_ph12
 		     &dcmi_d4_ph14 &dcmi_d5_pi4 &dcmi_d6_pi6 &dcmi_d7_pi7>;
 	pinctrl-names = "default";
-	bus-width = <8>;
-	hsync-active = <0>;
-	vsync-active = <0>;
-	pixelclk-active = <0>;
-	capture-rate = <1>;
 	dmas = <&dma1 0 75 (STM32_DMA_PERIPH_TO_MEMORY | STM32_DMA_PERIPH_NO_INC |
 			    STM32_DMA_MEM_INC | STM32_DMA_PERIPH_32BITS | STM32_DMA_MEM_32BITS |
 			    STM32_DMA_PRIORITY_HIGH) STM32_DMA_FIFO_FULL>; //FULL for 7670, default FIFO_1_4
 
 	port {
 		dcmi_ep_in: endpoint {
-			remote-endpoint = <&gc2145_ep_out>;
-			//remote-endpoint = <&ov7670_ep_out>;
+			remote-endpoint-label = "gc2145_ep_out";
+			// remote-endpoint-label = "ov7670_ep_out";
+			bus-width = <8>;
+			hsync-active = <0>;
+			vsync-active = <0>;
+			pclk-sample = <0>;
 		};
 	};
 };

--- a/variants/frdm_rw612_rw612/frdm_rw612_rw612.overlay
+++ b/variants/frdm_rw612_rw612/frdm_rw612_rw612.overlay
@@ -10,8 +10,7 @@
 	w25q512jvfiq: w25q512jvfiq@0 {
 			partitions {
 				user_sketch: partition@323000 {
-					label = "image-1";
-					reg = <0x00323000 DT_SIZE_M(3)>;
+					reg = <0x00323000 (DT_SIZE_M(3) - 0x3000)>;
 				};
 			};
 	};

--- a/west.yml
+++ b/west.yml
@@ -15,14 +15,17 @@ manifest:
       url-base: https://github.com/arduino
     - name: facchinm
       url-base: https://github.com/facchinm
+    - name: pillo79
+      url-base: https://github.com/pillo79
 
   projects:
     - name: zephyr
       remote: arduino
-      revision: arduino_core_merge_post_4.1
+      revision: zephyr-arduino-20250520
       import:
         name-allowlist:
           - cmsis
+          - cmsis_6
           - hal_nordic
           - hal_ti
           - hal_ambiq


### PR DESCRIPTION
- fix `build.sh` requiring Python env or `ZEPHYR_SDK_INSTALL_DIR`
- fix `readelf` not being found in CI
- add missing `cmsis_6` submodule
- fix DCMI overlays
- fix merged shield name
