### PR TITLE
bootstrap.sh: limit Zephyr HALs by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,20 @@ After running the `bootstrap.sh` script, you can symlink the core to `$sketchboo
 
 ## 🚀 Adding a new target
 
+> [!TIP]
+>
+> While Zephyr supports a lot of different hardware targets, only the few
+> currently used by the Arduino core are installed by default. To add the
+> support for every Zephyr target to your workspace, run the following
+> commands:
+>
+> ```bash
+> . venv/bin/activate
+> west config -d manifest.project-filter
+> west sdk install --version 0.17.0
+> west update
+> ```
+
 To add a new board that is already supported by mainline Zephyr with the target `$your_board`, follow these steps:
 
 * Get the variant name from your board by running `extra/get_variant_name.sh $your_board`.
@@ -195,7 +209,10 @@ To add a new board that is already supported by mainline Zephyr with the target 
 * Build the Loader: run `./extra/build.sh $your_board` (with any additional arguments as required) and start debugging the errors. :grin:
 * Update the `boards.txt`: add an entry for your board, manually filling the required fields.
 
-  In particular, set `build.zephyr_target` and `build.zephyr_args` to the arguments used in the `build.sh` call, and `build.variant` to the variant name identified above.
+  Make sure to set:
+   * `build.zephyr_target` and `build.zephyr_args` to the arguments used in the `build.sh` call;
+   * `build.zephyr_hals` to the (space-separated list of) HAL modules required by the board;
+   * `build.variant` to the variant name identified above.
 * Implement touch support: if your board supports the "1200bps touch" method, implement `_on_1200_bps` in a file located inside the variant folder of your board.
 
 ## 🐛 Bug Reporting

--- a/boards.txt
+++ b/boards.txt
@@ -14,6 +14,7 @@ giga.menu.debug.true.postbuild_debug=-debug
 
 giga.build.zephyr_target=arduino_giga_r1//m7
 giga.build.zephyr_args=--shield arduino_giga_display_shield
+giga.build.zephyr_hals=hal_stm32
 giga.build.variant=arduino_giga_r1_stm32h747xx_m7
 giga.build.mcu=cortex-m7
 giga.build.fpu=-mfpu=fpv5-d16
@@ -79,6 +80,7 @@ nano33ble.menu.debug.true.postbuild_debug=-debug
 
 nano33ble.build.zephyr_target=arduino_nano_33_ble//sense
 nano33ble.build.zephyr_args=
+nano33ble.build.zephyr_hals=hal_nordic
 nano33ble.build.variant=arduino_nano_33_ble_nrf52840_sense
 nano33ble.build.mcu=cortex-m4
 nano33ble.build.fpu=-mfpu=fpv4-sp-d16
@@ -142,6 +144,7 @@ ek_ra8d1.menu.debug.true.postbuild_debug=-debug
 
 ek_ra8d1.build.zephyr_target=ek_ra8d1
 ek_ra8d1.build.zephyr_args=
+ek_ra8d1.build.zephyr_hals=hal_renesas
 ek_ra8d1.build.variant=ek_ra8d1_r7fa8d1bhecbd
 ek_ra8d1.build.mcu=cortex-m85+nomve
 ek_ra8d1.build.fpu=-mfpu=fpv5-d16
@@ -200,6 +203,7 @@ frdm_mcxn947.menu.debug.true.postbuild_debug=-debug
 
 frdm_mcxn947.build.zephyr_target=frdm_mcxn947//cpu0
 frdm_mcxn947.build.zephyr_args=
+frdm_mcxn947.build.zephyr_hals=hal_nxp
 frdm_mcxn947.build.variant=frdm_mcxn947_mcxn947_cpu0
 frdm_mcxn947.build.mcu=cortex-m33
 frdm_mcxn947.build.fpu=-mfpu=fpv5-sp-d16
@@ -253,6 +257,7 @@ portentah7.menu.debug.true.postbuild_debug=-debug
 
 portentah7.build.zephyr_target=arduino_portenta_h7@1.0.0//m7
 portentah7.build.zephyr_args=
+portentah7.build.zephyr_hals=hal_stm32
 portentah7.build.variant=arduino_portenta_h7_stm32h747xx_m7
 portentah7.build.mcu=cortex-m7
 portentah7.build.fpu=-mfpu=fpv5-d16
@@ -318,6 +323,7 @@ frdm_rw612.menu.debug.true.postbuild_debug=-debug
 
 frdm_rw612.build.zephyr_target=frdm_rw612
 frdm_rw612.build.zephyr_args=
+frdm_rw612.build.zephyr_hals=hal_stm32
 frdm_rw612.build.variant=frdm_rw612_rw612
 frdm_rw612.build.mcu=cortex-m33+nodsp
 frdm_rw612.build.fpu=-mfpu=fpv5-sp-d16
@@ -370,6 +376,7 @@ niclasense.menu.debug.true.postbuild_debug=-debug
 
 niclasense.build.zephyr_target=arduino_nicla_sense_me
 niclasense.build.zephyr_args=
+niclasense.build.zephyr_hals=hal_nordic
 niclasense.build.variant=arduino_nicla_sense_me_nrf52832
 niclasense.build.mcu=cortex-m4
 niclasense.build.fpu=-mfpu=fpv4-sp-d16
@@ -449,6 +456,7 @@ portentac33.menu.mode.linked.postbuild_mode=-prelinked
 
 portentac33.build.zephyr_target=arduino_portenta_c33
 portentac33.build.zephyr_args=
+portentac33.build.zephyr_hals=hal_renesas
 portentac33.build.variant=arduino_portenta_c33_r7fa6m5bh3cfc
 portentac33.build.mcu=cortex-m33
 portentac33.build.fpu=-mfpu=fpv5-sp-d16
@@ -504,6 +512,7 @@ opta.menu.debug.true.postbuild_debug=-debug
 
 opta.build.zephyr_target=arduino_opta//m7
 opta.build.zephyr_args=
+opta.build.zephyr_hals=hal_stm32
 opta.build.variant=arduino_opta_stm32h747xx_m7
 opta.build.mcu=cortex-m7
 opta.build.fpu=-mfpu=fpv5-d16

--- a/extra/bootstrap.sh
+++ b/extra/bootstrap.sh
@@ -5,14 +5,23 @@ if [ ! -f platform.txt ]; then
   exit 2
 fi
 
+NEEDED_HALS=$(grep 'build.zephyr_hals=' boards.txt | cut -d '=' -f 2 | xargs -n 1 echo | sort -u)
+
+HAL_FILTER="-hal_.*"
+for hal in $NEEDED_HALS; do
+  HAL_FILTER="$HAL_FILTER,+$hal"
+done
+
 python3 -m venv venv
 source venv/bin/activate
 pip install west
 west init -l .
+west config manifest.project-filter -- "$HAL_FILTER"
 west update "$@"
 west zephyr-export
 pip install -r ../zephyr/scripts/requirements-base.txt
 west sdk install --version 0.17.0 -t arm-zephyr-eabi
 
-# add here the required blobs based on supported platforms
-west blobs fetch hal_nxp
+for hal in $NEEDED_HALS; do
+	west blobs fetch $hal
+done

--- a/extra/build_all.sh
+++ b/extra/build_all.sh
@@ -2,7 +2,7 @@
 
 FORCE=false
 
-while getopts "hfl" opt; do
+while getopts "hf" opt; do
 	case $opt in
 		h)
 			echo "Usage: $0 [-hfl]"

--- a/extra/get_board_details.sh
+++ b/extra/get_board_details.sh
@@ -14,11 +14,16 @@ for BOARD in $(get_boards); do
 	VARIANT=$(get_board_field $BOARD "variant")
 	TARGET=$(get_board_field $BOARD "zephyr_target")
 	ARGS=$(get_board_field $BOARD "zephyr_args")
+	HALS=$(get_board_field $BOARD "zephyr_hals")
 
 	if [ -z "$TARGET" ] ; then
 		echo "error: missing '$BOARD.build.zephyr_target'" 1>&2
 		exit 1
 	fi
+	if [ -z "$HALS" ] ; then
+		echo "error: missing '$BOARD.build.zephyr_hals'" 1>&2
+		exit 1
+	fi
 
-	echo "{ \"board\": \"$BOARD\", \"variant\": \"$VARIANT\", \"target\": \"$TARGET\", \"args\": \"$ARGS\" }"
+	echo "{ \"board\": \"$BOARD\", \"variant\": \"$VARIANT\", \"target\": \"$TARGET\", \"args\": \"$ARGS\", \"hals\": \"$HALS\" }"
 done | jq -crs .

--- a/west.yml
+++ b/west.yml
@@ -26,21 +26,6 @@ manifest:
         name-allowlist:
           - cmsis
           - cmsis_6
-          - hal_nordic
-          - hal_ti
-          - hal_ambiq
-          - hal_espressif
-          - hal_infineon
-          - hal_intel
-          - hal_nxp
-          - hal_stm32
-          - hal_xtensa
-          - hal_nordic
-          - hal_renesas
-          - hal_adi
-          - hal_atmel
-          - hal_rpi_pico
-          - hal_silabs
           - littlefs
           - tinycrypt
           - mbedtls
@@ -48,6 +33,14 @@ manifest:
           - thrift
           - mcuboot
           - lvgl
+        path-allowlist:
+          - modules/hal/*
+
+        # The actual list of enabled HALs is set by extra/bootstrap.sh via
+        # the 'manifest.project-filter' config. Enable all Zephyr HALs with:
+        #
+        #   west config -d manifest.project-filter
+
     - name: ArduinoCore-API
       path: modules/lib/ArduinoCore-API
       revision: master


### PR DESCRIPTION
This reworks the current `west.yml` and `bootstrap.sh` so that only the HALs used by the Arduino core are installed by default.

Since those not named in the allowlist are discarded during the Zephyr import, it is impossible to allow the option to install every HAL that way. Instead, allow all HALs by path, then filter them by group using the `manifest.project-filter` config that is automatically set by `bootstrap.sh`. This allows to enable all HALs, if needed, by simply removing the filter.