### PR TITLE
Beginning touch support

### DIFF
--- a/loader/fixups.c
+++ b/loader/fixups.c
@@ -39,16 +39,47 @@ SYS_INIT(disable_bootloader_mpu, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAU
 SYS_INIT(disable_mpu_rasr_xn, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
 #endif
 
-#if defined(CONFIG_BOARD_ARDUINO_GIGA_R1) && defined(CONFIG_VIDEO)
+
+#if defined(CONFIG_BOARD_ARDUINO_GIGA_R1)  && defined(CONFIG_INPUT_GT911_INTERRUPT)
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
-#include <zephyr/drivers/clock_control.h>
 #include <zephyr/logging/log.h>
+
+#include <zephyr/input/input.h>
+
+// experiment to try to capture touch screen events
+void (*_giga_touch_callback)(struct input_event *evt, void *user_data) = 0;
+
+void registerGigaTouchCallback(void (*cb)(struct input_event *evt, void *user_data)) {	
+	_giga_touch_callback = cb;
+}
+
+
+void touch_event_callback(struct input_event *evt, void *user_data)
+{
+    //printk("touch_event_callback(%p %p): %p %u %u %u %d\n", evt, user_data,
+    //        evt->dev, evt->sync, evt->type, evt->code, evt->value);
+	if (_giga_touch_callback) {
+		(*_giga_touch_callback)(evt, user_data);
+	}
+}
+
+static const struct device *const touch_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_touch));
+INPUT_CALLBACK_DEFINE(touch_dev, touch_event_callback, NULL);
+
+#endif
+
+#if (defined(CONFIG_BOARD_ARDUINO_GIGA_R1) || defined(CONFIG_BOARD_ARDUINO_PORTENTA_H7) ) && defined(CONFIG_VIDEO)
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/drivers/clock_control.h>
 
 int camera_ext_clock_enable(void)
 {
 	int ret;
 	uint32_t rate;
+
 	const struct device *cam_ext_clk_dev = DEVICE_DT_GET(DT_NODELABEL(pwmclock));
 
 	if (!device_is_ready(cam_ext_clk_dev)) {

--- a/loader/llext_exports.c
+++ b/loader/llext_exports.c
@@ -134,6 +134,9 @@ FORCE_EXPORT_SYM(video_buffer_alloc);
 FORCE_EXPORT_SYM(video_buffer_release);
 FORCE_EXPORT_SYM(video_set_ctrl);
 #endif
+#if defined(CONFIG_BOARD_ARDUINO_GIGA_R1) && defined(CONFIG_INPUT_GT911_INTERRUPT)
+FORCE_EXPORT_SYM(registerGigaTouchCallback);
+#endif
 
 #if defined(CONFIG_SHARED_MULTI_HEAP)
 FORCE_EXPORT_SYM(shared_multi_heap_aligned_alloc);

--- a/variants/arduino_giga_r1_stm32h747xx_m7/variant.cpp
+++ b/variants/arduino_giga_r1_stm32h747xx_m7/variant.cpp
@@ -6,3 +6,12 @@ void _on_1200_bps() {
     *(__IO uint32_t *)tmp = (uint32_t)0xDF59;
     NVIC_SystemReset();
 }
+
+#if defined(CONFIG_BOARD_ARDUINO_GIGA_R1)  && defined(CONFIG_INPUT_GT911_INTERRUPT)
+extern "C" void registerGigaTouchCallback(void (*cb)(struct input_event *evt, void *user_data));
+void initVariant(void) {
+    // Make sure to set to NULL in case previous sketch or pvevious build of sketch 
+    // set a callback, whoes pointer may not be valid
+    registerGigaTouchCallback(nullptr);
+}
+#endif


### PR DESCRIPTION
Add a callback function for the touch device
within the fixups for the GIGA.  This callback
simply remembers the last touch that happened and
sets a semaphore.

There is also a function added to retrieve this data.

Needed to add the callback function into the exports file.

EDIT: As I mentioned in 
https://github.com/arduino/ArduinoCore-zephyr/issues/92

This is maybe not a complete setup yet.  Currently the zephyr touch device is configured for only one touch
Where it believe is supposed to support up to 5.   Also with it only doing one touch, it does not support
gestures.  I will integrate our WIP touch code into the Arduino_GIGATouch library such that it is all
available for us or others to fill this in.