### PR TITLE
Upate Camera support to reflect changes in API

### DIFF
--- a/loader/llext_exports.c
+++ b/loader/llext_exports.c
@@ -129,6 +129,7 @@ FORCE_EXPORT_SYM(__stack_chk_fail);
 FORCE_EXPORT_SYM(video_buffer_aligned_alloc);
 FORCE_EXPORT_SYM(video_buffer_alloc);
 FORCE_EXPORT_SYM(video_buffer_release);
+FORCE_EXPORT_SYM(video_set_ctrl);
 #endif
 
 #if defined(CONFIG_SHARED_MULTI_HEAP)


### PR DESCRIPTION
Was retesting the GC2145 with the giga and found that the camera library no longer works - compile errors.  Seems the api changed in zephyr so made the appropriate changes in the camera library but also had to make an addition to llext_exports.c.

Seems to work when connected directly to the giga but now when camera is attached to giga display shield but going to make that a separate issue.