### PR TITLE
Fix .c file compile that include <Arduino.h>

### DIFF
--- a/variants/arduino_giga_r1_stm32h747xx_m7/pure_analog_pins.h
+++ b/variants/arduino_giga_r1_stm32h747xx_m7/pure_analog_pins.h
@@ -1,5 +1,6 @@
 #ifndef _PURE_ANALOG_PINS_
 #define _PURE_ANALOG_PINS_
+#ifdef __cplusplus
 
 /******************************************************************************
  * INCLUDE
@@ -53,5 +54,7 @@ int       analogRead  (PureAnalogPin pin);
 void      PURE_ANALOG_AS_DIGITAL_ATTRIBUTE analogWrite (PureAnalogPin pin, int value);
 
 #undef PURE_ANALOG_AS_DIGITAL_ATTRIBUTE
+
+#endif /* __cplusplus */
 
 #endif /* _PURE_ANALOG_PINS_ */

--- a/variants/arduino_portenta_h7_stm32h747xx_m7/pure_analog_pins.h
+++ b/variants/arduino_portenta_h7_stm32h747xx_m7/pure_analog_pins.h
@@ -5,6 +5,7 @@
  */
 #ifndef _PURE_ANALOG_PINS_
 #define _PURE_ANALOG_PINS_
+#ifdef __cplusplus
 
 /******************************************************************************
  * INCLUDE
@@ -58,5 +59,7 @@ int       analogRead  (PureAnalogPin pin);
 void      PURE_ANALOG_AS_DIGITAL_ATTRIBUTE analogWrite (PureAnalogPin pin, int value);
 
 #undef PURE_ANALOG_AS_DIGITAL_ATTRIBUTE
+
+#endif /* __cplusplus */
 
 #endif /* _PURE_ANALOG_PINS_ */


### PR DESCRIPTION
Both GIGA and Portenta H7 have the files pure_analog_pins.h which is included within Arduino.h

If you should by chance have a .c file either in library or sketch that include Arduino.h such as simple file:
foo.c
```
#include <Arduino.h>

void foo() {

}
```
The build will fail with errors like:
```
In file included from C:\Users\kurte\Documents\Arduino\hardware\arduino-git\ArduinoCore-zephyr\variants\arduino_portenta_h7_stm32h747xx_m7/variant.h:6,
                 from C:\Users\kurte\Documents\Arduino\hardware\arduino-git\ArduinoCore-zephyr\cores\arduino/Arduino.h:133,
                 from C:\Users\kurte\AppData\Local\Temp\.arduinoIDE-unsaved2025512-1916-i38ngk.ik13\sketch_jun12a\foo.c:1:
C:\Users\kurte\Documents\Arduino\hardware\arduino-git\ArduinoCore-zephyr\variants\arduino_portenta_h7_stm32h747xx_m7/pure_analog_pins.h:25:1: error: unknown type name 'class'
   25 | class PureAnalogPin {
      | ^~~~~
C:\Users\kurte\Documents\Arduino\hardware\arduino-git\ArduinoCore-zephyr\variants\arduino_portenta_h7_stm32h747xx_m7/pure_analog_pins.h:25:21: error: expected '=', ',', ';', 'asm' or '__attribute__' before '{' token
   25 | class PureAnalogPin {
      |                     ^
C:\Users\kurte\Documents\Arduino\hardware\arduino-git\ArduinoCore-zephyr\variants\arduino_portenta_h7_stm32h747xx_m7/pure_analog_pins.h:40:8: error: unknown type name 'PureAnalogPin'
   40 | extern PureAnalogPin  A0_PURE;
      |        ^~~~~~~~~~~~~
C:\Users\kurte\Documents\Arduino\hardware\arduino-git\ArduinoCore-zephyr\variants\arduino_portenta_h7_stm32h747xx_m7/pure_analog_pins.h:41:8: error: unknown type name 'PureAnalogPin'
   41 | extern PureAnalogPin  A1_PURE;
      |        ^~~~~~~~~~~~~
C:\Users\kurte\Documents\Arduino\hardware\arduino-git\ArduinoCore-zephyr\variants\arduino_portenta_h7_stm32h747xx_m7/pure_analog_pins.h:42:8: error: unknown type name 'PureAnalogPin'
   42 | extern PureAnalogPin  A2_PURE;
      |        ^~~~~~~~~~~~~
C:\Users\kurte\Documents\Arduino\hardware\arduino-git\ArduinoCore-zephyr\variants\arduino_portenta_h7_stm32h747xx_m7/pure_analog_pins.h:43:8: error: unknown type name 'PureAnalogPin'
   43 | extern PureAnalogPin  A3_PURE;
      |        ^~~~~~~~~~~~~
C:\Users\kurte\Documents\Arduino\hardware\arduino-git\ArduinoCore-zephyr\variants\arduino_portenta_h7_stm32h747xx_m7/pure_analog_pins.h:54:57: error: unknown type name 'PureAnalogPin'
   54 | void      PURE_ANALOG_AS_DIGITAL_ATTRIBUTE pinMode     (PureAnalogPin pin, PinMode mode);
      |                                                         ^~~~~~~~~~~~~
C:\Users\kurte\Documents\Arduino\hardware\arduino-git\ArduinoCore-zephyr\variants\arduino_portenta_h7_stm32h747xx_m7/pure_analog_pins.h:55:57: error: unknown type name 'PureAnalogPin'
   55 | PinStatus PURE_ANALOG_AS_DIGITAL_ATTRIBUTE digitalRead (PureAnalogPin pin);
      |                                                         ^~~~~~~~~~~~~
C:\Users\kurte\Documents\Arduino\hardware\arduino-git\ArduinoCore-zephyr\variants\arduino_portenta_h7_stm32h747xx_m7/pure_analog_pins.h:56:57: error: unknown type name 'PureAnalogPin'
   56 | void      PURE_ANALOG_AS_DIGITAL_ATTRIBUTE digitalWrite(PureAnalogPin pin, PinStatus value);
      |                                                         ^~~~~~~~~~~~~
C:\Users\kurte\Documents\Arduino\hardware\arduino-git\ArduinoCore-zephyr\variants\arduino_portenta_h7_stm32h747xx_m7/pure_analog_pins.h:57:24: error: unknown type name 'PureAnalogPin'
   57 | int       analogRead  (PureAnalogPin pin);
      |                        ^~~~~~~~~~~~~
C:\Users\kurte\Documents\Arduino\hardware\arduino-git\ArduinoCore-zephyr\variants\arduino_portenta_h7_stm32h747xx_m7/pure_analog_pins.h:58:57: error: unknown type name 'PureAnalogPin'
   58 | void      PURE_ANALOG_AS_DIGITAL_ATTRIBUTE analogWrite (PureAnalogPin pin, int value);
      |                                                         ^~~~~~~~~~~~~
exit status 1

Compilation error: exit status 1

Fix is to simply add #ifdef __cplusplus to the header files (along with #endif ...