### PR TITLE
SerialUSB: fix missing overload after #123

### DIFF
--- a/cores/arduino/SerialUSB.h
+++ b/cores/arduino/SerialUSB.h
@@ -19,6 +19,7 @@ public:
 
 	operator bool() override;
 	size_t write(const uint8_t *buffer, size_t size) override;
+	size_t write(const uint8_t data) override { return write(&data, 1); }
 	void flush() override;
 
 protected:


### PR DESCRIPTION
This would have been spotted if we extend the CI to compile all the examples (TestClient in particular).