### PR TITLE
Add WiFiWebClient example

### DIFF
--- a/cores/arduino/SerialUSB.h
+++ b/cores/arduino/SerialUSB.h
@@ -19,6 +19,7 @@ public:
 
 	operator bool() override;
 	size_t write(const uint8_t *buffer, size_t size) override;
+	size_t write(const uint8_t data) override { return write(&data, 1); }
 	void flush() override;
 
 protected:

--- a/libraries/SocketWrapper/WiFi.h
+++ b/libraries/SocketWrapper/WiFi.h
@@ -75,14 +75,12 @@ public:
     }
 
     int status() {
-        struct wifi_iface_status status = { 0 };
-
-        if (net_mgmt(NET_REQUEST_WIFI_IFACE_STATUS, netif, &status,
+        if (net_mgmt(NET_REQUEST_WIFI_IFACE_STATUS, netif, &sta_state,
                 sizeof(struct wifi_iface_status))) {
             return WL_NO_SHIELD;
         }
 
-	    if (status.state >= WIFI_STATE_ASSOCIATED) {
+	    if (sta_state.state >= WIFI_STATE_ASSOCIATED) {
             return WL_CONNECTED;
         } else {
             return WL_DISCONNECTED;
@@ -94,12 +92,28 @@ public:
         // TODO: borrow code from mbed core for scan results handling
     }
 
+    char* SSID() {
+        if (status() == WL_CONNECTED) {
+            return (char *)sta_state.ssid;
+        }
+        return nullptr;
+    }
+
+    int32_t RSSI() {
+        if (status() == WL_CONNECTED) {
+            return sta_state.rssi;
+        }
+        return 0;
+    }
+
 private:
     struct net_if *sta_iface = nullptr;
     struct net_if *ap_iface = nullptr;
 
     struct wifi_connect_req_params ap_config;
     struct wifi_connect_req_params sta_config;
+
+    struct wifi_iface_status sta_state = { 0 };
 };
 
 extern WiFiClass WiFi;

--- a/libraries/SocketWrapper/WiFi.h
+++ b/libraries/SocketWrapper/WiFi.h
@@ -16,7 +16,7 @@ public:
     WiFiClass() {}
     ~WiFiClass() {}
 
-    bool begin(const char* ssid, const char* passphrase, wl_enc_type security = ENC_TYPE_UNKNOWN, bool blocking = true) {
+    int begin(const char* ssid, const char* passphrase, wl_enc_type security = ENC_TYPE_UNKNOWN, bool blocking = true) {
         sta_iface = net_if_get_wifi_sta();
         netif = sta_iface;
         sta_config.ssid = (const uint8_t *)ssid;
@@ -40,7 +40,7 @@ public:
             net_mgmt_event_wait_on_iface(sta_iface, NET_EVENT_WIFI_CONNECT_RESULT, NULL, NULL, NULL, K_FOREVER);
         }
 
-        return true;
+        return status();
     }
 
     bool beginAP(char* ssid, char* passphrase, int channel = WIFI_CHANNEL_ANY, bool blocking = false) {

--- a/libraries/SocketWrapper/WiFi.h
+++ b/libraries/SocketWrapper/WiFi.h
@@ -37,7 +37,7 @@ public:
 
         NetworkInterface::begin(false, NET_EVENT_WIFI_MASK);
         if (blocking) {
-            net_mgmt_event_wait_on_iface(sta_iface, NET_EVENT_WIFI_AP_STA_CONNECTED, NULL, NULL, NULL, K_FOREVER);
+            net_mgmt_event_wait_on_iface(sta_iface, NET_EVENT_WIFI_CONNECT_RESULT, NULL, NULL, NULL, K_FOREVER);
         }
 
         return true;

--- a/libraries/SocketWrapper/WiFi.h
+++ b/libraries/SocketWrapper/WiFi.h
@@ -75,6 +75,8 @@ public:
     }
 
     int status() {
+        sta_iface = net_if_get_wifi_sta();
+        netif = sta_iface;
         if (net_mgmt(NET_REQUEST_WIFI_IFACE_STATUS, netif, &sta_state,
                 sizeof(struct wifi_iface_status))) {
             return WL_NO_SHIELD;

--- a/libraries/SocketWrapper/WiFi.h
+++ b/libraries/SocketWrapper/WiFi.h
@@ -16,7 +16,7 @@ public:
     WiFiClass() {}
     ~WiFiClass() {}
 
-    bool begin(const char* ssid, const char* passphrase, wl_enc_type security = ENC_TYPE_UNKNOWN, bool blocking = false) {
+    bool begin(const char* ssid, const char* passphrase, wl_enc_type security = ENC_TYPE_UNKNOWN, bool blocking = true) {
         sta_iface = net_if_get_wifi_sta();
         netif = sta_iface;
         sta_config.ssid = (const uint8_t *)ssid;

--- a/libraries/SocketWrapper/examples/WiFiWebClient/WiFiWebClient.ino
+++ b/libraries/SocketWrapper/examples/WiFiWebClient/WiFiWebClient.ino
@@ -1,0 +1,106 @@
+/*
+  Web client
+
+ This sketch connects to a website (http://example.com) using the WiFi module.
+
+ This example is written for a network using WPA encryption. For
+ WEP or WPA, change the Wifi.begin() call accordingly.
+
+ created 13 July 2010
+ by dlf (Metodo2 srl)
+ modified 31 May 2012
+ by Tom Igoe
+ */
+
+#include <ZephyrClient.h>
+#include <WiFi.h>
+
+#include "arduino_secrets.h"
+///////please enter your sensitive data in the Secret tab/arduino_secrets.h
+char ssid[] = SECRET_SSID;        // your network SSID (name)
+char pass[] = SECRET_PASS;        // your network password (use for WPA, or use as key for WEP)
+int keyIndex = 0;                 // your network key Index number (needed only for WEP)
+
+int status = WL_IDLE_STATUS;
+// if you don't want to use DNS (and reduce your sketch size)
+// use the numeric IP instead of the name for the server:
+// IPAddress server(93,184,216,34);  // IP address for example.com (no DNS)
+char server[] = "example.com";       // host name for example.com (using DNS)
+
+ZephyrClient client;
+
+void setup() {
+  //Initialize serial and wait for port to open:
+  Serial.begin(9600);
+  while (!Serial) {
+    ; // wait for serial port to connect. Needed for native USB port only
+  }
+
+  // check for the WiFi module:
+  if (WiFi.status() == WL_NO_SHIELD) {
+    Serial.println("Communication with WiFi module failed!");
+    // don't continue
+    while (true);
+  }
+
+  // attempt to connect to Wifi network:
+  while (status != WL_CONNECTED) {
+    Serial.print("Attempting to connect to SSID: ");
+    Serial.println(ssid);
+    // Connect to WPA/WPA2 network. Change this line if using open or WEP network:
+    status = WiFi.begin(ssid, pass);
+    Serial.println(status);
+    // wait 3 seconds for connection:
+    delay(3000);
+  }
+  Serial.println("Connected to wifi");
+  printWifiStatus();
+
+  Serial.println("\nStarting connection to server...");
+  // if you get a connection, report back via serial:
+  if (client.connect(server, 80)) {
+    Serial.println("connected to server");
+    // Make a HTTP request:
+    client.println("GET /index.html HTTP/1.1");
+    client.print("Host: ");
+    client.println(server);
+    client.println("Connection: close");
+    client.println();
+  }
+}
+
+void loop() {
+  // if there are incoming bytes available
+  // from the server, read them and print them:
+  while (client.available()) {
+    char c = client.read();
+    Serial.write(c);
+  }
+
+  // if the server's disconnected, stop the client:
+  if (!client.connected()) {
+    Serial.println();
+    Serial.println("disconnecting from server.");
+    client.stop();
+
+    // do nothing forevermore:
+    while (true);
+  }
+}
+
+void printWifiStatus() {
+  // print the SSID of the network you're attached to:
+  Serial.print("SSID: ");
+  Serial.println(WiFi.SSID());
+
+  // print your board's IP address:
+  IPAddress ip = WiFi.localIP();
+  Serial.print("IP Address: ");
+  Serial.println(ip);
+
+  // print the received signal strength:
+  long rssi = WiFi.RSSI();
+  Serial.print("signal strength (RSSI):");
+  Serial.print(rssi);
+  Serial.println(" dBm");
+}

--- a/libraries/SocketWrapper/examples/WiFiWebClient/arduino_secrets.h
+++ b/libraries/SocketWrapper/examples/WiFiWebClient/arduino_secrets.h
@@ -1,0 +1,2 @@
+#define SECRET_SSID ""
+#define SECRET_PASS ""


### PR DESCRIPTION
This PR is a work in progress.

Some configs to enable debug:

```
CONFIG_NET_LOG=y
CONFIG_NET_L2_WIFI_MGMT_LOG_LEVEL_DBG=y
CONFIG_WIFI_LOG_LEVEL_DBG=y
```

Can happen that connection fails due to:

`<err> esp_hosted: failed to receive response for 206`

Increasing [ESP_HOSTED_SYNC_TIMEOUT](https://github.com/zephyrproject-rtos/zephyr/blame/f2c37c4b13252352472cbab98907c0a3fce2b2d4/drivers/wifi/esp_hosted/esp_hosted_wifi.h#L25C9-L25C32) does not help. Adding a `delay(100)` in `WiFi.begin()` before return `status()` works, but there should be a better solution.

Probably we should wait until `NET_EVENT_IPV4_ADDR_ADD`.

Disabling debug prints makes connection even less reliable.