### PR TITLE
Switch to the official 4.2.0 release of Zephyr

### DIFF
--- a/extra/build.sh
+++ b/extra/build.sh
@@ -82,12 +82,15 @@ line_comment_only='^\s*\/\*' # match lines starting with comment
 line_continuation='\\$' # match lines ending with '\'
 c_comment='\s*\/\*.*?\*\/' # match C-style comments and any preceding space
 perl -i -pe "s/${c_comment}//gs unless /${line_preproc_ok}/ || (/${line_comment_only}/ && !/${line_continuation}/)" $(find ${VARIANT_DIR}/llext-edk/include/ -type f)
+
 for ext in elf bin hex; do
     rm -f firmwares/zephyr-$variant.$ext
     if [ -f ${BUILD_DIR}/zephyr/zephyr.$ext ]; then
         cp ${BUILD_DIR}/zephyr/zephyr.$ext firmwares/zephyr-$variant.$ext
     fi
 done
+cp ${BUILD_DIR}/zephyr/zephyr.dts firmwares/zephyr-$variant.dts
+cp ${BUILD_DIR}/zephyr/.config firmwares/zephyr-$variant.config
 
 # Generate the provides.ld file for linked builds
 echo "Generating exported symbol scripts"

--- a/west.yml
+++ b/west.yml
@@ -21,7 +21,7 @@ manifest:
   projects:
     - name: zephyr
       remote: arduino
-      revision: zephyr-arduino-20250714
+      revision: zephyr-arduino-v4.2.0
       import:
         name-allowlist:
           - cmsis


### PR DESCRIPTION
Kconfig and DTS files generated by the build are now added to firmwares/ folder.
No other major updates, just a sync to the official tag. 