### PR TITLE
README.md - How one can build on windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,21 +142,17 @@ brew install python cmake ninja zstd jq git
 Note: Homebrew’s Python installation already includes `pip`, `setuptools` and `venv`.
 
 ### On Windows
-While installing and building natively on zephyr is supported as described at: https://docs.zephyrproject.org/latest/develop/getting_started/index.html. 
+Windows is not currently supported. However it is possible to setup and build the loader using WSL. You will need to follow the instructions given above for installing on Ubuntu.
 
-Arduino currently has not ported their build setup to the Windows environment.  However it is possible to setup and build the loaders on a Windows system using WSL and use the resulting Loader files within Windows.  You will need to follow the instructions given above
-for installing on Ubuntu.
+There are two strategies:
+1) Install the sources in the native Windows filesystem (NTFS, FAT32, etc) and within WSL, cd to the root directory where you installed your sources, like: `/mnt/d/github/ArduinoCore-zephyr`.
+2) Install the sources within the WSL file system, like: `~/git/ArduinoCore-zephyr`
 
-There are at least two strategies. 
-1) Install the sources in the native Windows filesystem (NTFS, FAT32, etc) and within WSL, cd to the root directory where you installed your sources, like: /mnt/d/github/ArduinoCore-zephyr.
+There are pros and cons to both strategies:
+1) Builds are relatively very slow, but once done you can use it directly within Arduino. 
+2) Builds are a lot faster, however, you need to copy the resulting build back to somewhere in your windows directory structure. It is this location, that you will add to the Arduino IDE as mentioned below in the section: Using the core in Arduino IDE/CLI.
 
-2) Install the sources within the WSL file system, like: ~/git/ArduinoCore-zephyr
-
-There are pros and cons to both strategies.  With 1) Builds are relatively very slow, but once done you can use it directly within
-Arduino.  With 2) Builds are a lot faster, however, you then need to copy the resulting build back to somewhere in your windows directory
-structure.  It is this location, that you will add to the Arduino IDE as mentioned below in the section: Using the core in Arduino IDE/CLI
-
-In either strategy, you may have to update the link: cores\arduino\api as sometimes this link file may or may not work properly.
+In either strategy, you may have to update the link: `cores\arduino\api`.
 
 ### Run the ```bootstrap``` script
 ```bash


### PR DESCRIPTION
I keep wondering why, Windows users are excluded from being mentioned and/or finding
solutions for building for Zephyr.  

Especially in the current state of Zephyr, where everyone more or less probably needs to rebuild the
different loaders, to even do simple changes like choose a different Camera or the speed of it, etc.

So here is a cut at, at least showing that it is currently doable to build under Windows.  Would be nice if 
there was native support and not having to resort to using WSL, but...