### PR TITLE
Add support for receiving input callback in sketches. 

### DIFF
--- a/loader/fixups.c
+++ b/loader/fixups.c
@@ -50,6 +50,27 @@ int enable_bkp_access(void)
 SYS_INIT(enable_bkp_access, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
 #endif
 
+#if defined(CONFIG_INPUT)
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/input/input.h>
+typedef void (*zephyr_input_callback_t)(struct input_event *evt, void *user_data);
+
+static zephyr_input_callback_t zephyr_input_cb = NULL;
+
+void zephyr_input_register_callback(zephyr_input_callback_t cb) {
+	zephyr_input_cb = cb;
+}
+
+static void zephyr_input_callback(struct input_event *evt, void *user_data) {
+	if (zephyr_input_cb) {
+		zephyr_input_cb(evt, user_data);
+    }
+}
+
+INPUT_CALLBACK_DEFINE(NULL, zephyr_input_callback, NULL);
+#endif
+
 #if defined(CONFIG_BOARD_ARDUINO_GIGA_R1) && defined(CONFIG_VIDEO)
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>

--- a/loader/llext_exports.c
+++ b/loader/llext_exports.c
@@ -141,6 +141,9 @@ FORCE_EXPORT_SYM(video_buffer_alloc);
 FORCE_EXPORT_SYM(video_buffer_release);
 FORCE_EXPORT_SYM(video_set_ctrl);
 #endif
+#if defined(CONFIG_INPUT)
+FORCE_EXPORT_SYM(zephyr_input_register_callback);
+#endif
 
 #if defined(CONFIG_SHARED_MULTI_HEAP)
 FORCE_EXPORT_SYM(shared_multi_heap_aligned_alloc);


### PR DESCRIPTION
Add a callback function for the touch device
within the fixups for the GIGA. This callback
simply remembers the last touch that happened and
sets a semaphore.

There is also a function added to retrieve this data.

Needed to add the callback function into the exports file.

EDIT: As I mentioned in
https://github.com/arduino/ArduinoCore-zephyr/issues/92

This is maybe not a complete setup yet. Currently the zephyr touch device is configured for only one touch
Where it believe is supposed to support up to 5. Also with it only doing one touch, it does not support
gestures. I will integrate our WIP touch code into the Arduino_GIGATouch library such that it is all
available for us or others to fill this in.

This is a replacement for #134 
... 
See that one for more details, like, I have an open PR for the touch library to work on zephyr...
https://github.com/arduino-libraries/Arduino_GigaDisplayTouch/pull/14

<img width="263" height="202" alt="image" src="https://github.com/user-attachments/assets/8b4fbfaf-c0bf-40d1-b37b-937b9eaf0f29" />
