### PR TITLE
fixing net_mgmt event handler callback signature after zephyr #89048

### DIFF
--- a/libraries/SocketWrapper/SocketHelpers.h
+++ b/libraries/SocketWrapper/SocketHelpers.h
@@ -30,7 +30,7 @@ private:
     static struct net_dhcpv4_option_callback dhcp_cb;
 
     static void event_handler(struct net_mgmt_event_callback *cb,
-                uint32_t mgmt_event,
+                uint64_t mgmt_event,
                 struct net_if *iface)
     {
         int i = 0;


### PR DESCRIPTION
[github.com/zephyrproject-rtos/zephyr/pull/89048 ](http://github.com/zephyrproject-rtos/zephyr/pull/89048)