### PR TITLE
opta: fix i2c1 pins conflicting with BLE hci

### DIFF
--- a/variants/arduino_opta_stm32h747xx_m7/arduino_opta_stm32h747xx_m7.overlay
+++ b/variants/arduino_opta_stm32h747xx_m7/arduino_opta_stm32h747xx_m7.overlay
@@ -23,7 +23,7 @@
 
 &i2c1 {
 	status = "okay";
-	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
+	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb7>;
 	pinctrl-names = "default";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };


### PR DESCRIPTION
Assign pb6(scl) and pb7(sda) to i2c1