### PR TITLE
opta: swap i2c1 and i2c3 to restore compatibility with mbed cores

### DIFF
--- a/variants/arduino_opta_stm32h747xx_m7/arduino_opta_stm32h747xx_m7.overlay
+++ b/variants/arduino_opta_stm32h747xx_m7/arduino_opta_stm32h747xx_m7.overlay
@@ -101,7 +101,7 @@
 
 		serials = <&board_cdc_acm_uart>, <&usart3>, <&usart6>;
 		cdc-acm = <&board_cdc_acm_uart>;
-		i2cs = <&i2c1>, <&i2c3>;
+		i2cs = <&i2c3>, <&i2c1>;
 
 		io-channels =	<&adc1 0>,
 				<&adc3 0>,


### PR DESCRIPTION
With mbed core
Wire uses PH_7 PH_8 pins connected to the expansion bus Wire 1 uses PB_6 PB_7 pins connected to the crypto