### PR TITLE
camera: try to defer init of video objects

### DIFF
--- a/libraries/Camera/src/camera.cpp
+++ b/libraries/Camera/src/camera.cpp
@@ -50,16 +50,73 @@ Camera::Camera() : byte_swap(false), yuv_to_gray(false), vdev(NULL) {
 	}
 }
 
+#if defined(CONFIG_VIDEO)
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/clock_control.h>
+#include <zephyr/logging/log.h>
+
+int camera_ext_clock_enable(void) {
+	int ret;
+	uint32_t rate;
+	const struct device *cam_ext_clk_dev = DEVICE_DT_GET(DT_NODELABEL(pwmclock));
+
+	if (!cam_ext_clk_dev) {
+		return -ENODEV;		
+	}
+
+	(void)zephyr::arduino::init_dev_apply_pinctrl(cam_ext_clk_dev);
+
+	ret = clock_control_on(cam_ext_clk_dev, (clock_control_subsys_t)0);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = clock_control_get_rate(cam_ext_clk_dev, (clock_control_subsys_t)0, &rate);
+	if (ret < 0) {
+		return ret;
+	}
+
+	return 0;
+}
+#else
+#ERROR "CONFIG_VIDEO is not defined for this variant"
+#endif
+
 bool Camera::begin(uint32_t width, uint32_t height, uint32_t pixformat, bool byte_swap) {
 #if DT_HAS_CHOSEN(zephyr_camera)
 	this->vdev = DEVICE_DT_GET(DT_CHOSEN(zephyr_camera));
 #endif
 
+	// start the clock
+	int ret;
+
 	if (!this->vdev) {
 		return false;
 	}
 
-	(void)zephyr::arduino::init_dev_apply_pinctrl(this->vdev);
+	if ((ret = camera_ext_clock_enable()) != 0) {
+		printk("Camera::begin failed = clock enable: %d\n", ret);
+		return false;
+	}
+
+	delay(50);
+
+	if ((ret = zephyr::arduino::init_dev_apply_pinctrl(this->vdev)) != 0) {
+		printk("Camera::begin failed = vedev: %d\n", ret);
+		return false;
+	}
+
+
+	// Now see if the actual camera is defined in choosen. And see if it is ready
+#if DT_HAS_CHOSEN(zephyr_camera_sensor)
+	const struct device *camera_sensor = DEVICE_DT_GET(DT_CHOSEN(zephyr_camera_sensor));
+	if ((ret = zephyr::arduino::init_dev_apply_pinctrl(camera_sensor)) != 0) {
+		printk("Camera::begin failed = sensor: %d\n", ret);
+		return false;
+	}
+
+#endif
 
 	switch (pixformat) {
 	case CAMERA_RGB565:

--- a/loader/fixups.c
+++ b/loader/fixups.c
@@ -76,38 +76,6 @@ static void zephyr_input_callback(struct input_event *evt, void *user_data) {
 INPUT_CALLBACK_DEFINE(NULL, zephyr_input_callback, NULL);
 #endif
 
-#if defined(CONFIG_BOARD_ARDUINO_GIGA_R1) && defined(CONFIG_VIDEO)
-#include <zephyr/kernel.h>
-#include <zephyr/device.h>
-#include <zephyr/drivers/clock_control.h>
-#include <zephyr/logging/log.h>
-
-int camera_ext_clock_enable(void) {
-	int ret;
-	uint32_t rate;
-	const struct device *cam_ext_clk_dev = DEVICE_DT_GET(DT_NODELABEL(pwmclock));
-
-	if (!device_is_ready(cam_ext_clk_dev)) {
-		return -ENODEV;
-	}
-
-	ret = clock_control_on(cam_ext_clk_dev, (clock_control_subsys_t)0);
-	if (ret < 0) {
-		return ret;
-	}
-
-	ret = clock_control_get_rate(cam_ext_clk_dev, (clock_control_subsys_t)0, &rate);
-	if (ret < 0) {
-		return ret;
-	}
-
-	return 0;
-}
-
-SYS_INIT(camera_ext_clock_enable, POST_KERNEL, CONFIG_CLOCK_CONTROL_PWM_INIT_PRIORITY);
-
-#endif
-
 #if defined(CONFIG_SHARED_MULTI_HEAP)
 #include <zephyr/kernel.h>
 #include <zephyr/devicetree.h>

--- a/variants/arduino_giga_r1_stm32h747xx_m7/arduino_giga_r1_stm32h747xx_m7.overlay
+++ b/variants/arduino_giga_r1_stm32h747xx_m7/arduino_giga_r1_stm32h747xx_m7.overlay
@@ -54,6 +54,7 @@
 	gc2145: gc2145@3c {
 		compatible = "galaxycore,gc2145";
 		reg = <0x3c>;
+		zephyr,deferred-init;
 		reset-gpios = <&gpiod 4 GPIO_ACTIVE_LOW>;
 		pwdn-gpios = <&gpioa 1 GPIO_ACTIVE_LOW>;
 
@@ -193,6 +194,7 @@
 
 &dcmi {
 	status = "okay";
+	zephyr,deferred-init;
 	/* ext-sdram = <&sdram1>; */
 	pinctrl-0 = <&dcmi_hsync_ph8 &dcmi_pixclk_pa6 &dcmi_vsync_pi5
 				&dcmi_d0_ph9 &dcmi_d1_ph10 &dcmi_d2_ph11 &dcmi_d3_pg11
@@ -380,6 +382,7 @@
 /{
 	chosen {
 		zephyr,camera = &dcmi;
+		zephyr,camera-sensor = &gc2145;
 		zephyr,log-uart = &log_uarts;
 		/* zephyr,console = &board_cdc_acm_uart; */
 	};

--- a/variants/arduino_portenta_h7_stm32h747xx_m7/arduino_portenta_h7_stm32h747xx_m7.overlay
+++ b/variants/arduino_portenta_h7_stm32h747xx_m7/arduino_portenta_h7_stm32h747xx_m7.overlay
@@ -44,6 +44,7 @@
 	gc2145: gc2145@3c {
 		compatible = "galaxycore,gc2145";
 		reg = <0x3c>;
+		zephyr,deferred-init;
 		status = "okay";
 
 		reset-gpios = <&gpioe 3 GPIO_ACTIVE_LOW>;
@@ -171,6 +172,7 @@
 
 &dcmi {
 	status = "okay";
+	zephyr,deferred-init;
 	/* ext-sdram = <&sdram1>; */
 	pinctrl-0 = <&dcmi_hsync_pa4 &dcmi_pixclk_pa6 &dcmi_vsync_pi5
 		     &dcmi_d0_ph9 &dcmi_d1_ph10 &dcmi_d2_ph11 &dcmi_d3_ph12
@@ -290,6 +292,7 @@
 / {
 	chosen {
 		zephyr,camera = &dcmi;
+		zephyr,camera-sensor = &gc2145;
 		zephyr,console = &usart6;
 		zephyr,shell-uart = &usart6;
 		zephyr,cdc-acm-uart0 = &usart6;


### PR DESCRIPTION
This change, removes the automatic starting of the PWM clock on the GIGA, at startup.  Instead it starts the clock if/when the sketch calls the Camera::begin method.

But to make this work, we also need to not start up the video objects, until after the MCLK has been started.  We can do that with marking them as zephyr,deferred-init

This is to me a better solution to adding Portenta H7 than #184 as again this
only starts up (uses) the video resources IF you actually use them in your sketch.

Some of this is discussed in the Arduino discussion: https://github.com/zephyrproject-rtos/zephyr/discussions/93058#discussioncomment-14332014

