### PR TITLE
ci: replace Docker image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,15 +28,22 @@ jobs:
           persist-credentials: false
           path: subfolder
 
-      - name: Fix module path
+      - name: Fix module path, list needed HALs
         run: |
           mkdir -p $(dirname $MODULE_PATH) && mv subfolder $MODULE_PATH
+          NEEDED_HALS=$(grep 'build.zephyr_hals=' $MODULE_PATH/boards.txt | cut -d '=' -f 2 | xargs -n 1 echo | sort -u)
+          HAL_FILTER="-hal_.*"
+          for hal in $NEEDED_HALS; do
+            HAL_FILTER="$HAL_FILTER,+$hal"
+          done
+          echo "HAL_FILTER=$HAL_FILTER" | tee -a $GITHUB_ENV
 
       - name: Setup Zephyr project
         uses: zephyrproject-rtos/action-zephyr-setup@v1
         with:
           toolchains: arm-zephyr-eabi
           manifest-file-name: ${{ env.MODULE_PATH }}/west.yml
+          west-project-filter: ${{ env.HAL_FILTER }}
 
       - name: Add manifest path as module
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,7 @@ jobs:
           toolchains: arm-zephyr-eabi
           manifest-file-name: ${{ env.MODULE_PATH }}/west.yml
           west-project-filter: ${{ env.HAL_FILTER }}
+          enable-ccache: false
 
       - name: Add manifest path as module
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,35 +6,50 @@ jobs:
   build:
     name: Build native Zephyr samples
     runs-on: ubuntu-latest
-    container: zephyrprojectrtos/ci:latest
+    container: zephyrprojectrtos/ci-base:latest
     env:
       CMAKE_PREFIX_PATH: /opt/toolchains
       CCACHE_IGNOREOPTIONS: -specs=*
-      REPOSITORY: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
-      BRANCH: ${{ github.event.pull_request.head.ref || github.ref_name }}
-    steps:
-      - name: Initialize
-        run: |
-          mkdir build && cd build
-          west init -m https://github.com/${{ env.REPOSITORY }} --mr ${{ env.BRANCH }}
-          west update -o=--filter=tree:0
+      MODULE_PATH: ../modules/lib/ArduinoCore-zephyr
 
-      - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2
+      # action-setup-zephyr will initialize the repo in $GITHUB_WORKSPACE/..,
+      # so we need to put the module in $GITHUB_WORKSPACE's parent, but
+      # actions/checkout would not be able to checkout the module there
+      # directly, so we use "subfolder" and move it later.
+      #
+      # using action-setup-zephyr also requires a local west.yml and so the
+      # folder must be manually added to Zephyr as a module via
+      # EXTRA_ZEPHYR_MODULES.
+
+    steps:
+      - uses: actions/checkout@v4
         with:
-          verbose: 1
+          fetch-depth: 0
+          persist-credentials: false
+          path: subfolder
+
+      - name: Fix module path
+        run: |
+          mkdir -p $(dirname $MODULE_PATH) && mv subfolder $MODULE_PATH
+
+      - name: Setup Zephyr project
+        uses: zephyrproject-rtos/action-zephyr-setup@v1
+        with:
+          toolchains: arm-zephyr-eabi
+          manifest-file-name: ${{ env.MODULE_PATH }}/west.yml
+
+      - name: Add manifest path as module
+        run: |
+          echo EXTRA_ZEPHYR_MODULES="$(pwd)/$MODULE_PATH" >> $GITHUB_ENV
 
       - name: Build fade
-        working-directory: build
         run: |
-          west build -p -b arduino_nano_33_ble//sense modules/lib/ArduinoCore-zephyr/samples/fade
+          west build -p -b arduino_nano_33_ble//sense $MODULE_PATH/samples/fade
 
       - name: Build i2cdemo
-        working-directory: build
         run: |
-          west build -p -b ek_ra8d1 modules/lib/ArduinoCore-zephyr/samples/i2cdemo
+          west build -p -b ek_ra8d1 $MODULE_PATH/samples/i2cdemo
 
       - name: Build adc
-        working-directory: build
         run: |
-          west build -p -b arduino_nano_33_ble/nrf52840/sense modules/lib/ArduinoCore-zephyr/samples/analog_input
+          west build -p -b arduino_nano_33_ble/nrf52840/sense $MODULE_PATH/samples/analog_input


### PR DESCRIPTION
The current `ci` Docker image is too large for the basic Github runner. Switch to `ci-base` and manually run `action-zephyr-setup` reduces the image size and makes it run again.