### PR TITLE
ldscripts: fix static thread data section name

### DIFF
--- a/variants/_ldscripts/build-dynamic.ld
+++ b/variants/_ldscripts/build-dynamic.ld
@@ -36,7 +36,7 @@ SECTIONS {
         KEEP (*(.fini))
 
         __static_thread_data_list_start = .;
-        KEEP(*(SORT_BY_NAME(.__static_thread_data.static.*)));
+        KEEP(*(SORT_BY_NAME(.static_thread_data_area .__static_thread_data.static.*)));
         __static_thread_data_list_end = .;
     }
 


### PR DESCRIPTION
Add more name alternatives to the linker script to match the actual section names generated by GCC in some configurations (this was from a UNO Q build of the weather forecast sketch).