### PR TITLE
WiFi: add scan()

### DIFF
--- a/libraries/WiFi/examples/ScanNetworksAdvanced/ScanNetworksAdvanced.ino
+++ b/libraries/WiFi/examples/ScanNetworksAdvanced/ScanNetworksAdvanced.ino
@@ -1,0 +1,125 @@
+/*
+  This example  prints the board's MAC address, and
+  scans for available WiFi networks using the NINA module.
+  Every ten seconds, it scans again. It doesn't actually
+  connect to any network, so no encryption scheme is specified.
+  BSSID and WiFi channel are printed
+
+  This example is based on ScanNetworks
+
+  created 1 Mar 2017
+  by Arturo Guadalupi
+*/
+
+
+
+#include <WiFi.h>
+
+int numSsid = 0; // number of networks found
+
+void setup() {
+  //Initialize serial and wait for port to open:
+  Serial.begin(9600);
+  while (!Serial) {
+    ; // wait for serial port to connect. Needed for native USB port only
+  }
+
+  // check for the WiFi module:
+  if (WiFi.status() == WL_NO_MODULE) {
+    Serial.println("Communication with WiFi module failed!");
+    // don't continue
+    while (true);
+  }
+}
+
+void loop() {
+    // scan for existing networks:
+  Serial.println("Scanning available networks...");
+  numSsid = WiFi.scanNetworks();
+  if (numSsid <= 0) {
+    Serial.println("No networks found, trying again...");
+    delay(1000);
+  }
+  else
+  {
+    listNetworks();
+  }
+}
+
+int listNetworks() {
+  // list nearby networks:
+  Serial.println("** Scan Networks Result **");
+
+  // print the list of networks seen:
+  Serial.print("number of available networks: ");
+  Serial.println(numSsid);
+
+  // print the network number and name for each network found:
+  for (int thisNet = 0; thisNet < numSsid; thisNet++) {
+    Serial.print(thisNet + 1);
+    Serial.print(") ");
+    Serial.print("Signal: ");
+    Serial.print(WiFi.RSSI(thisNet));
+    Serial.print(" dBm");
+    Serial.print("\tChannel: ");
+    Serial.print(WiFi.channel(thisNet));
+    byte bssid[6];
+    Serial.print("\t\tBSSID: ");
+    printMacAddress(WiFi.BSSID(thisNet, bssid));
+    Serial.print("\tEncryption: ");
+    printEncryptionType(WiFi.encryptionType(thisNet));
+    Serial.print("\t\tSSID: ");
+    Serial.println(WiFi.SSID(thisNet));
+    Serial.flush();
+  }
+  Serial.println();
+  return numSsid;
+}
+
+void printEncryptionType(int thisType) {
+  // read the encryption type and print out the name:
+  switch (thisType) {
+    case ENC_TYPE_WEP:
+      Serial.print("WEP");
+      break;
+    case ENC_TYPE_WPA:
+      Serial.print("WPA");
+      break;
+    case ENC_TYPE_WPA2:
+      Serial.print("WPA2");
+      break;
+    case ENC_TYPE_NONE:
+      Serial.print("None");
+      break;
+    case ENC_TYPE_AUTO:
+      Serial.print("Auto");
+      break;
+    case ENC_TYPE_WPA3:
+      Serial.print("WPA3");
+      break;
+    case ENC_TYPE_UNKNOWN:
+    default:
+      Serial.print("Unknown");
+      break;
+  }
+}
+
+void print2Digits(byte thisByte) {
+  if (thisByte < 0xF) {
+    Serial.print("0");
+  }
+  Serial.print(thisByte, HEX);
+}
+
+void printMacAddress(byte mac[]) {
+  for (int i = 0; i < 6; i++) {
+    if (i > 0) {
+      Serial.print(":");
+    }
+    if (mac[i] < 16) {
+      Serial.print("0");
+    }
+    Serial.print(mac[i], HEX);
+  }
+  Serial.println();
+}

--- a/libraries/WiFi/src/WiFi.cpp
+++ b/libraries/WiFi/src/WiFi.cpp
@@ -6,10 +6,76 @@
 
 #include "WiFi.h"
 
+#include <errno.h>
 #include <zephyr/logging/log.h>
-LOG_MODULE_DECLARE(sketch, LOG_LEVEL_DBG);
+LOG_MODULE_REGISTER(WiFi, LOG_LEVEL_NONE);
+
+namespace {
+
+constexpr wifi_security_type encryptionTypeToSecType(wl_enc_type enc_type) {
+	switch (enc_type) {
+	case ENC_TYPE_WEP:
+		return WIFI_SECURITY_TYPE_WEP;
+	case ENC_TYPE_WPA:
+		return WIFI_SECURITY_TYPE_WPA_PSK;
+	case ENC_TYPE_WPA2:
+		return WIFI_SECURITY_TYPE_PSK;
+	case ENC_TYPE_WPA3:
+		return WIFI_SECURITY_TYPE_SAE;
+	case ENC_TYPE_NONE:
+		return WIFI_SECURITY_TYPE_NONE;
+	case ENC_TYPE_UNKNOWN:
+	case ENC_TYPE_AUTO:
+	default:
+		return WIFI_SECURITY_TYPE_UNKNOWN;
+	}
+}
+
+constexpr wl_enc_type secTypeToEncryptionType(wifi_security_type security) {
+	switch (security) {
+	case WIFI_SECURITY_TYPE_WEP:
+		return ENC_TYPE_WEP;
+	case WIFI_SECURITY_TYPE_PSK:
+		return ENC_TYPE_WPA2;
+	case WIFI_SECURITY_TYPE_WPA_AUTO_PERSONAL:
+		return ENC_TYPE_WPA2;
+	case WIFI_SECURITY_TYPE_SAE:
+		return ENC_TYPE_WPA3;
+	case WIFI_SECURITY_TYPE_SAE_AUTO:
+		return ENC_TYPE_WPA3;
+	case WIFI_SECURITY_TYPE_NONE:
+		return ENC_TYPE_NONE;
+	default:
+		return ENC_TYPE_UNKNOWN;
+	}
+}
+
+} // namespace
 
 WiFiClass WiFi;
+
+WiFiClass::WiFiClass() {
+}
+
+void WiFiClass::wifiScanEventHandler(struct net_mgmt_event_callback *cb, uint64_t mgmt_event,
+									 struct net_if *iface) {
+	ARG_UNUSED(iface);
+
+	if (mgmt_event == NET_EVENT_WIFI_SCAN_RESULT) {
+		const struct wifi_scan_result *entry =
+			reinterpret_cast<const struct wifi_scan_result *>(cb->info);
+		WiFi.handleScanResult(entry);
+	} else if (mgmt_event == NET_EVENT_WIFI_SCAN_DONE) {
+		WiFi.wifiState.flags |= WIFI_FLAG_SCAN_SEQUENCE_FINISHED;
+	}
+}
+
+void WiFiClass::registerScanEventCallback() {
+	net_mgmt_del_event_callback(&wifiScanCb);
+	net_mgmt_init_event_callback(&wifiScanCb, wifiScanEventHandler,
+								 NET_EVENT_WIFI_SCAN_RESULT | NET_EVENT_WIFI_SCAN_DONE);
+	net_mgmt_add_event_callback(&wifiScanCb);
+}
 
 const char *WiFiClass::firmwareVersion() {
 #if defined(ARDUINO_PORTENTA_C33)
@@ -21,25 +87,50 @@ const char *WiFiClass::firmwareVersion() {
 
 int WiFiClass::begin(const char *ssid, const char *passphrase, wl_enc_type security,
 					 bool blocking) {
-	ARG_UNUSED(security); // currently unsupported
+	wifi_security_type wifi_security = encryptionTypeToSecType(security);
 
-	sta_iface = net_if_get_wifi_sta();
-	netif = sta_iface;
-	sta_config.ssid = (const uint8_t *)ssid;
-	sta_config.ssid_length = strlen(ssid);
-	sta_config.psk = (const uint8_t *)passphrase;
-	sta_config.psk_length = strlen(passphrase);
-	// TODO: change these fields with scan() results
-	sta_config.security = WIFI_SECURITY_TYPE_PSK;
-	sta_config.channel = WIFI_CHANNEL_ANY;
-	sta_config.band = WIFI_FREQ_BAND_2_4_GHZ;
-	sta_config.bandwidth = WIFI_FREQ_BANDWIDTH_20MHZ;
+	wifiState.sta_iface = net_if_get_wifi_sta();
+	netif = wifiState.sta_iface;
+	wifiState.sta_config.ssid = (const uint8_t *)ssid;
+	wifiState.sta_config.ssid_length = strlen(ssid);
+	if (passphrase != nullptr) {
+		wifiState.sta_config.psk = (const uint8_t *)passphrase;
+		wifiState.sta_config.psk_length = strlen(passphrase);
+	} else {
+		wifiState.sta_config.psk = nullptr;
+		wifiState.sta_config.psk_length = 0u;
+	}
+
+	wifiState.sta_config.channel = WIFI_CHANNEL_ANY;
+	wifiState.sta_config.band = WIFI_FREQ_BAND_2_4_GHZ;
+	wifiState.sta_config.bandwidth = WIFI_FREQ_BANDWIDTH_20MHZ;
+	/* security will be updated in case of ENC_TYPE_UNKNOWN in handleScanResult when the network is
+	 * found during scanning */
+	wifiState.sta_config.security = wifi_security;
 
 	if (!net_if_is_up(netif)) {
 		net_if_up(netif);
 	}
 
-	int ret = net_mgmt(NET_REQUEST_WIFI_CONNECT, sta_iface, &sta_config,
+	if (security == ENC_TYPE_UNKNOWN) {
+		int8_t scan_result_count = scanNetworks();
+
+		if (scan_result_count < 0 || !isNetworkFound()) {
+			/* When scan is flaky try PSK connect anyway. */
+			wifiState.sta_config.security = WIFI_SECURITY_TYPE_PSK;
+			LOG_WRN("Scan did not determine security (scan_result=%d), falling back to PSK connect",
+					scan_result_count);
+		}
+
+		/*
+		 * Small delay to ensure the driver is ready for the next command: the Arduino
+		 * WIFI_FLAG_SCAN_SEQUENCE_FINISHED flag that we use as a marker can be set slightly before
+		 * the driver finishes its internal scan cleanup.
+		 */
+		k_sleep(K_MSEC(100));
+	}
+
+	int ret = net_mgmt(NET_REQUEST_WIFI_CONNECT, wifiState.sta_iface, &wifiState.sta_config,
 					   sizeof(struct wifi_connect_req_params));
 	if (ret) {
 		return false;
@@ -47,51 +138,82 @@ int WiFiClass::begin(const char *ssid, const char *passphrase, wl_enc_type secur
 
 	ret = status();
 	if (ret != WL_CONNECTED && blocking) {
-		net_mgmt_event_wait_on_iface(sta_iface, NET_EVENT_WIFI_CONNECT_RESULT, NULL, NULL, NULL,
-									 K_FOREVER);
+		net_mgmt_event_wait_on_iface(wifiState.sta_iface, NET_EVENT_WIFI_CONNECT_RESULT, NULL, NULL,
+									 NULL, K_FOREVER);
 	}
 	NetworkInterface::begin(blocking, NET_EVENT_WIFI_MASK);
 	return status();
 }
 
 bool WiFiClass::beginAP(char *ssid, char *passphrase, int channel, bool blocking) {
-	if (ap_iface != NULL) {
+	if (wifiState.ap_iface != nullptr) {
 		return false;
 	}
-	ap_iface = net_if_get_wifi_sap();
-	netif = ap_iface;
-	ap_config.ssid = (const uint8_t *)ssid;
-	ap_config.ssid_length = strlen(ssid);
-	ap_config.psk = (const uint8_t *)passphrase;
-	ap_config.psk_length = strlen(passphrase);
-	ap_config.security = WIFI_SECURITY_TYPE_PSK;
-	ap_config.channel = channel;
-	ap_config.band = WIFI_FREQ_BAND_2_4_GHZ;
-	ap_config.bandwidth = WIFI_FREQ_BANDWIDTH_20MHZ;
+
+	wifiState.ap_iface = net_if_get_wifi_sap();
+	netif = wifiState.ap_iface;
+	wifiState.ap_config.ssid = (const uint8_t *)ssid;
+	wifiState.ap_config.ssid_length = strlen(ssid);
+	wifiState.ap_config.psk = (const uint8_t *)passphrase;
+	wifiState.ap_config.psk_length = strlen(passphrase);
+	wifiState.ap_config.security = WIFI_SECURITY_TYPE_PSK;
+	wifiState.ap_config.channel = channel;
+	wifiState.ap_config.band = WIFI_FREQ_BAND_2_4_GHZ;
+	wifiState.ap_config.bandwidth = WIFI_FREQ_BANDWIDTH_20MHZ;
 
 	if (!net_if_is_up(netif)) {
 		net_if_up(netif);
 	}
 
-	int ret = net_mgmt(NET_REQUEST_WIFI_AP_ENABLE, ap_iface, &ap_config,
+	int ret = net_mgmt(NET_REQUEST_WIFI_AP_ENABLE, wifiState.ap_iface, &wifiState.ap_config,
 					   sizeof(struct wifi_connect_req_params));
 	if (ret) {
 		return false;
 	}
-	enable_dhcpv4_server(ap_iface);
+
+	enable_dhcpv4_server(wifiState.ap_iface);
+
 	if (blocking) {
-		net_mgmt_event_wait_on_iface(ap_iface, NET_EVENT_WIFI_AP_ENABLE_RESULT, NULL, NULL, NULL,
-									 K_FOREVER);
+		net_mgmt_event_wait_on_iface(wifiState.ap_iface, NET_EVENT_WIFI_AP_ENABLE_RESULT, NULL,
+									 NULL, NULL, K_FOREVER);
 	}
+
 	return true;
+}
+
+void WiFiClass::handleScanResult(const struct wifi_scan_result *entry) {
+	if (wifiState.scanResults.size() < MAX_SCAN_RESULTS) {
+		wifiState.scanResults.push_back(*entry);
+		wifiState.resultCount = wifiState.scanResults.size();
+	} else {
+		LOG_WRN("WiFi scan result buffer full (%u), dropping additional result", MAX_SCAN_RESULTS);
+	}
+
+	if (entry->ssid_length == wifiState.sta_config.ssid_length &&
+		strncmp(reinterpret_cast<const char *>(entry->ssid),
+				reinterpret_cast<const char *>(wifiState.sta_config.ssid),
+				entry->ssid_length) == 0) {
+		wifiState.sta_config.security = entry->security;
+		wifiState.sta_config.channel = entry->channel;
+		wifiState.sta_config.band = entry->band;
+		wifiState.sta_config.bandwidth = WIFI_FREQ_BANDWIDTH_20MHZ;
+		wifiState.flags |= WIFI_FLAG_NETWORK_FOUND;
+
+		LOG_INF("Network found: %.*s, RSSI: %d, Security: %d", entry->ssid_length, entry->ssid,
+				entry->rssi, entry->security);
+	}
+}
+
+const struct wifi_scan_result *WiFiClass::getScanResults() const {
+	return wifiState.scanResults.data();
 }
 
 int WiFiClass::status() {
 	struct wifi_iface_status if_status;
 
 	if (netif == nullptr) {
-		sta_iface = net_if_get_wifi_sta();
-		netif = sta_iface;
+		wifiState.sta_iface = net_if_get_wifi_sta();
+		netif = wifiState.sta_iface;
 	}
 
 	if (net_mgmt(NET_REQUEST_WIFI_IFACE_STATUS, netif, &if_status,
@@ -100,7 +222,7 @@ int WiFiClass::status() {
 	}
 
 	if (if_status.iface_mode != WIFI_MODE_AP) {
-		memcpy(&sta_state, &if_status, sizeof(sta_state));
+		memcpy(&wifiState.sta_state, &if_status, sizeof(wifiState.sta_state));
 	}
 
 	if (if_status.state >= WIFI_STATE_ASSOCIATED) {
@@ -112,22 +234,60 @@ int WiFiClass::status() {
 }
 
 int8_t WiFiClass::scanNetworks() {
-	// TODO: borrow code from mbed core for scan results handling
-	return 0;
-}
+	wifiState.sta_iface = net_if_get_wifi_sta();
+	netif = wifiState.sta_iface;
 
-char *WiFiClass::SSID() {
-	if (status() == WL_CONNECTED) {
-		return (char *)sta_state.ssid;
+	if (!net_if_is_up(wifiState.sta_iface)) {
+		net_if_up(wifiState.sta_iface);
 	}
-	return nullptr;
-}
 
-int32_t WiFiClass::RSSI() {
-	if (status() == WL_CONNECTED) {
-		return sta_state.rssi;
+	wifiState.flags = 0u;
+	wifiState.scanResults.clear();
+	wifiState.scanResults.reserve(MAX_SCAN_RESULTS);
+	wifiState.resultCount = 0u;
+
+	struct wifi_scan_params params = {
+		.scan_type = WIFI_SCAN_TYPE_ACTIVE,
+	};
+
+	registerScanEventCallback();
+	int ret = 0;
+	constexpr int max_scan_start_retries = 3;
+	for (int attempt = 1; attempt <= max_scan_start_retries; ++attempt) {
+		ret = net_mgmt(NET_REQUEST_WIFI_SCAN, wifiState.sta_iface, &params, sizeof(params));
+		if (ret >= 0) {
+			break;
+		}
+
+		/* if the driver is busy, retry */
+		if ((ret == -EAGAIN || ret == -EBUSY) && attempt < max_scan_start_retries) {
+			LOG_WRN("WiFi scan start retry %d/%d (err=%d)", attempt, max_scan_start_retries - 1,
+					ret);
+			k_sleep(K_MSEC(100));
+			continue;
+		}
+		break;
 	}
-	return 0;
+
+	if (ret < 0) {
+		LOG_WRN("WiFi scan request failed (%d)", ret);
+		return ret;
+	}
+
+	if ((wifiState.flags & WIFI_FLAG_SCAN_SEQUENCE_FINISHED) != 0u) {
+		return wifiState.resultCount;
+	}
+
+	ret = net_mgmt_event_wait_on_iface(wifiState.sta_iface, NET_EVENT_WIFI_SCAN_DONE, nullptr,
+									   nullptr, nullptr,
+									   timeout_ms == 0 ? K_FOREVER : K_MSEC(timeout_ms));
+	if (ret == -ETIMEDOUT) {
+		LOG_INF("WiFi scan timed out ");
+	} else if (ret < 0) {
+		LOG_WRN("WiFi scan wait failed (%d)", ret);
+	}
+
+	return wifiState.resultCount;
 }
 
 bool WiFiClass::disconnect() {
@@ -143,4 +303,90 @@ bool WiFiClass::disconnect() {
 	ret = NetworkInterface::disconnect();
 
 	return ret;
+}
+
+char *WiFiClass::SSID(std::optional<uint8_t> networkItem) {
+	if (networkItem.has_value()) {
+		if (*networkItem >= wifiState.resultCount) {
+			return nullptr;
+		}
+
+		return (char *)wifiState.scanResults[*networkItem].ssid;
+	}
+
+	if (status() == WL_CONNECTED) {
+		return (char *)wifiState.sta_state.ssid;
+	}
+
+	return nullptr;
+}
+
+int32_t WiFiClass::RSSI(std::optional<uint8_t> networkItem) {
+	if (networkItem.has_value()) {
+		if (*networkItem >= wifiState.resultCount) {
+			return 0;
+		}
+
+		return wifiState.scanResults[*networkItem].rssi;
+	}
+
+	if (status() == WL_CONNECTED) {
+		return wifiState.sta_state.rssi;
+	}
+
+	return 0;
+}
+
+int8_t WiFiClass::channel(std::optional<uint8_t> networkItem) {
+	if (networkItem.has_value()) {
+		if (*networkItem >= wifiState.resultCount) {
+			return -1;
+		}
+
+		return wifiState.scanResults[*networkItem].channel;
+	}
+
+	if (status() == WL_CONNECTED) {
+		return wifiState.sta_state.channel;
+	}
+
+	return -1;
+}
+
+uint8_t *WiFiClass::BSSID(uint8_t *bssid) {
+	return BSSID(std::nullopt, bssid);
+}
+
+uint8_t *WiFiClass::BSSID(std::optional<uint8_t> networkItem, uint8_t *bssid) {
+	if (networkItem.has_value()) {
+		if (*networkItem >= wifiState.resultCount) {
+			return nullptr;
+		}
+
+		if (bssid != nullptr) {
+			memcpy(bssid, wifiState.scanResults[*networkItem].mac, WIFI_MAC_ADDR_LEN);
+			return bssid;
+		}
+	}
+
+	if (status() == WL_CONNECTED) {
+		if (bssid != nullptr) {
+			memcpy(bssid, wifiState.sta_state.bssid, WIFI_MAC_ADDR_LEN);
+			return bssid;
+		}
+	}
+
+	return nullptr;
+}
+
+uint8_t WiFiClass::encryptionType(std::optional<uint8_t> networkItem) {
+	if (networkItem.has_value()) {
+		if (*networkItem >= wifiState.resultCount) {
+			return WIFI_SECURITY_TYPE_UNKNOWN;
+		}
+
+		return secTypeToEncryptionType(wifiState.scanResults[*networkItem].security);
+	}
+
+	return secTypeToEncryptionType(wifiState.sta_state.security);
 }

--- a/libraries/WiFi/src/WiFi.h
+++ b/libraries/WiFi/src/WiFi.h
@@ -7,12 +7,17 @@
 #pragma once
 
 #include <Arduino.h>
+#include <optional>
+#include <vector>
+
 #include "SocketHelpers.h"
 #include "utility/wl_definitions.h"
 #include <zephyr/net/wifi_mgmt.h>
 #include "ZephyrClient.h"
 
 using WiFiClient = ZephyrClient;
+
+#define MAX_SCAN_RESULTS 20u
 
 #define NET_EVENT_WIFI_MASK                                                                        \
 	(NET_EVENT_WIFI_CONNECT_RESULT | NET_EVENT_WIFI_DISCONNECT_RESULT |                            \
@@ -22,36 +27,63 @@ using WiFiClient = ZephyrClient;
 
 class WiFiClass : public NetworkInterface {
 public:
-	WiFiClass() {
-	}
-
-	~WiFiClass() {
-	}
+	WiFiClass();
+	~WiFiClass() = default;
 
 	int begin(const char *ssid, const char *passphrase, wl_enc_type security = ENC_TYPE_UNKNOWN,
 			  bool blocking = true);
 	bool beginAP(char *ssid, char *passphrase, int channel = WIFI_CHANNEL_ANY,
 				 bool blocking = false);
 
+	void handleScanResult(const struct wifi_scan_result *entry);
+
+	const struct wifi_scan_result *getScanResults() const;
+
 	int status();
 
 	int8_t scanNetworks();
 
-	char *SSID();
-	int32_t RSSI();
+	char *SSID(std::optional<uint8_t> networkItem = std::nullopt);
+
+	int32_t RSSI(std::optional<uint8_t> networkItem = std::nullopt);
+
+	int8_t channel(std::optional<uint8_t> networkItem = std::nullopt);
+
+	uint8_t *BSSID(uint8_t *bssid);
+	uint8_t *BSSID(std::optional<uint8_t> networkItem, uint8_t *bssid);
+
+	uint8_t encryptionType(std::optional<uint8_t> networkItem = std::nullopt);
 
 	const char *firmwareVersion();
 
 	bool disconnect() override;
 
 private:
-	struct net_if *sta_iface = nullptr;
-	struct net_if *ap_iface = nullptr;
+	static constexpr uint8_t WIFI_FLAG_NETWORK_FOUND = 1u << 0;
+	static constexpr uint8_t WIFI_FLAG_SCAN_SEQUENCE_FINISHED = 1u << 1;
+	uint32_t timeout_ms = 30000u; // Default timeout for scanNetworks() is 30 seconds
 
-	struct wifi_connect_req_params ap_config;
-	struct wifi_connect_req_params sta_config;
+	static void wifiScanEventHandler(struct net_mgmt_event_callback *cb, uint64_t mgmt_event,
+									 struct net_if *iface);
+	void registerScanEventCallback();
 
-	struct wifi_iface_status sta_state = {0};
+	inline bool isNetworkFound() const {
+		return (wifiState.flags & WIFI_FLAG_NETWORK_FOUND) != 0u;
+	}
+
+	struct WiFiState {
+		struct net_if *sta_iface = nullptr;
+		struct net_if *ap_iface = nullptr;
+		struct wifi_connect_req_params ap_config;
+		struct wifi_connect_req_params sta_config;
+		struct wifi_iface_status sta_state = {0};
+		std::vector<struct wifi_scan_result> scanResults;
+		uint8_t resultCount = 0u;
+		uint8_t flags = 0u;
+	};
+
+	struct net_mgmt_event_callback wifiScanCb;
+	struct WiFiState wifiState;
 };
 
-extern WiFiClass WiFi;
+extern WiFiClass WiFi; // Global Wi-Fi object

--- a/loader/llext_exports.c
+++ b/loader/llext_exports.c
@@ -196,6 +196,7 @@ FORCE_EXPORT_SYM(net_dhcpv4_server_start);
 #if defined(CONFIG_NET_MGMT_EVENT)
 FORCE_EXPORT_SYM(net_mgmt_add_event_callback);
 FORCE_EXPORT_SYM(net_mgmt_event_wait_on_iface);
+FORCE_EXPORT_SYM(net_mgmt_del_event_callback);
 #endif
 
 #if defined(CONFIG_MBEDTLS)
@@ -213,6 +214,7 @@ EXPORT_SYMBOL(mbedtls_debug_set_threshold);
 FORCE_EXPORT_SYM(net_if_get_wifi_sta);
 FORCE_EXPORT_SYM(net_if_get_wifi_sap);
 FORCE_EXPORT_SYM(net_mgmt_NET_REQUEST_WIFI_CONNECT);
+FORCE_EXPORT_SYM(net_mgmt_NET_REQUEST_WIFI_SCAN);
 FORCE_EXPORT_SYM(net_mgmt_NET_REQUEST_WIFI_IFACE_STATUS);
 FORCE_EXPORT_SYM(net_mgmt_NET_REQUEST_WIFI_AP_ENABLE);
 FORCE_EXPORT_SYM(net_mgmt_NET_REQUEST_WIFI_DISCONNECT);


### PR DESCRIPTION
Implements Wi-Fi network scanning and added standard retrieval methods to fetch metadata from discovered access points:

```
WiFi.SSID()
WiFi.BSSID()
WiFi.RSSI()
WiFi.channel()
WiFi.encryptionType()
```