### PR TITLE
feat: unoq: enable menu for immediate mode

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -1,6 +1,7 @@
 menu.debug=Debug
 menu.link_mode=Link mode
 menu.flash_mode=Flash mode
+menu.wait_linux_boot=Startup mode
 
 ##########################################################################################
 
@@ -543,6 +544,9 @@ unoq.menu.flash_mode.flash=Flash
 unoq.menu.flash_mode.flash.openocd_cfg=flash_sketch.cfg
 unoq.menu.flash_mode.ram=RAM
 unoq.menu.flash_mode.ram.openocd_cfg=flash_sketch_ram.cfg
+unoq.menu.wait_linux_boot.yes=Wait for Linux
+unoq.menu.wait_linux_boot.no=Immediate
+unoq.menu.wait_linux_boot.no.build.boot_mode=immediate
 
 unoq.build.zephyr_target=arduino_uno_q
 unoq.build.zephyr_args=

--- a/extra/zephyr-sketch-tool/main.go
+++ b/extra/zephyr-sketch-tool/main.go
@@ -11,6 +11,7 @@ import (
 func main() {
 	var output = flag.String("output", "", "Output to a specific file (default: add -zsk.bin suffix)")
 	var debug = flag.Bool("debug", false, "Enable debugging mode")
+	var immediate = flag.Bool("immediate", false, "Start sketch immediately [UNO Q]")
 	var linked = flag.Bool("prelinked", false, "Provided file has already been linked to Zephyr")
 	var force = flag.Bool("force", false, "Ignore safety checks and overwrite the header")
 	var add_header = flag.Bool("add_header", false, "Add space for the header to the file")
@@ -58,6 +59,9 @@ func main() {
 	}
 	if *linked {
 		header.flags |= 0x02
+	}
+	if *immediate {
+		header.flags |= 0x04
 	}
 
 	var bytes = make([]byte, 9)

--- a/platform.txt
+++ b/platform.txt
@@ -50,6 +50,7 @@ compiler.zephyr.extra_ldflags=-lstdc++ -lsupc++
 build.extra_flags=
 build.extra_ldflags=
 build.link_mode=dynamic
+build.boot_mode=wait
 upload.extension=elf-zsk.bin
 
 build.ldscript.path={runtime.platform.path}/variants/_ldscripts
@@ -76,6 +77,8 @@ build.link_args.build-common="-Wl,-Map,{build.path}/{build.project_name}.map" -o
 build.zsk_args.debug=
 build.zsk_args.mode-dynamic=
 build.zsk_args.mode-static=-prelinked
+build.zsk_args.startup-mode-wait=
+build.zsk_args.startup-mode-immediate=-immediate
 
 # These can be overridden in platform.local.txt
 compiler.c.extra_flags=
@@ -132,8 +135,8 @@ recipe.objcopy.bin.pattern="{compiler.path}{compiler.elf2hex.cmd}" {compiler.elf
 recipe.objcopy.hex.pattern="{compiler.path}{compiler.elf2hex.cmd}" {compiler.elf2hex.hex.flags} {compiler.elf2hex.extra_flags} "{build.path}/{build.project_name}.elf" "{build.path}/{build.project_name}.hex"
 
 ## Mangle the file
-recipe.hooks.objcopy.postobjcopy.1.pattern="{runtime.tools.zephyr-sketch-tool.path}/zephyr-sketch-tool" {build.zsk_args.debug} {build.zsk_args.mode-{build.link_mode}} "{build.path}/{build.project_name}.elf"
-recipe.hooks.objcopy.postobjcopy.2.pattern="{runtime.tools.zephyr-sketch-tool.path}/zephyr-sketch-tool" {build.zsk_args.debug} {build.zsk_args.mode-{build.link_mode}} "{build.path}/{build.project_name}.bin"
+recipe.hooks.objcopy.postobjcopy.1.pattern="{runtime.tools.zephyr-sketch-tool.path}/zephyr-sketch-tool" {build.zsk_args.debug} {build.zsk_args.mode-{build.link_mode}} {build.zsk_args.startup-mode-{build.boot_mode}} "{build.path}/{build.project_name}.elf"
+recipe.hooks.objcopy.postobjcopy.2.pattern="{runtime.tools.zephyr-sketch-tool.path}/zephyr-sketch-tool" {build.zsk_args.debug} {build.zsk_args.mode-{build.link_mode}} {build.zsk_args.startup-mode-{build.boot_mode}} "{build.path}/{build.project_name}.bin"
 
 ## Compute size
 recipe.size.pattern="{compiler.path}{compiler.size.cmd}" -A "{build.path}/{build.project_name}.elf"


### PR DESCRIPTION
Selecting "Startup mode->Immediate" will instruct the loader to skip the boot animation and directly start the sketch.
Extra care should be taken to ensure that the Linux side is up before calling any Bridge function.

The status of Linux boot can be easily retrieved by checking the status of GPIO G13 (67 in Arduino world).

Please note that this will be operational only after a **new release of zephyr-sketch-tool**