### PR TITLE
unoq: fix: reversed A4 and A5 ADC channels and clarify pin assignments

### DIFF
--- a/variants/arduino_uno_q_stm32u585xx/arduino_uno_q_stm32u585xx.overlay
+++ b/variants/arduino_uno_q_stm32u585xx/arduino_uno_q_stm32u585xx.overlay
@@ -313,12 +313,12 @@
 		control-gpios = <&gpiog 13 GPIO_ACTIVE_HIGH>;    /* Internal SPI RDY */
 		analog-switch-gpios = <&gpioa 2 GPIO_ACTIVE_HIGH>;    /* Analog switch for VREF */
 
-		io-channels =	<&adc1 9>,
-				<&adc1 10>,
-				<&adc1 11>,
-				<&adc1 12>,
-				<&adc1 1>,
-				<&adc1 2>;
+		io-channels =	<&adc1 9>,     /* A0 - PA4 */
+				<&adc1 10>,   /* A1 - PA5 */
+				<&adc1 11>,   /* A2 - PA6 */
+				<&adc1 12>,   /* A3 - PA7 */
+				<&adc1 2>,    /* A4 - PC1 */
+				<&adc1 1>;    /* A5 - PC0 */
 
 		dac = <&dac1>;
 		dac-channels = <1>, <2>;


### PR DESCRIPTION
While testing the analog inputs on the Uno Q, I discovered that A4 and A5 were swapped in the device tree overlay. The corresponding channels can be found in the STM datasheet on page 111.

This took me a while to figure out because they were working perfectly when used as digital inputs. The error only appeared when I used them as ADC inputs.

I also added comments clarifying that the ADC lines refer to the A4 and A5 pins and their corresponding ports.