### PR TITLE
boards: arduino: giga_r1: Fix partition size.

### DIFF
--- a/variants/arduino_giga_r1_stm32h747xx_m7/arduino_giga_r1_stm32h747xx_m7.overlay
+++ b/variants/arduino_giga_r1_stm32h747xx_m7/arduino_giga_r1_stm32h747xx_m7.overlay
@@ -336,6 +336,13 @@
 
 &flash0 {
 	partitions {
+		/delete-node/ slot0_partition;
+
+		slot0_partition: partition@40000 {
+			label = "image-0";
+			reg = <0x040000 0xa0000>;
+		};
+
 		user_sketch: partition@e0000 {
 			reg = <0x0E0000 0x20000>;
 		};


### PR DESCRIPTION
With the current config, a debug loader overwrites the sketch.

The correct partition layout is (offset, size):
- 0x00000 - 0x40000 (256KB): Bootloader
- 0x40000 - 0xa0000 (640KB): llext loader
- 0xe0000 - 0x20000 (128KB): sketch