### PR TITLE
Variants: Changed 'built-in' LED from RED to GREEN on R1, C33 and H7.

### DIFF
--- a/variants/arduino_giga_r1_stm32h747xx_m7/arduino_giga_r1_stm32h747xx_m7.overlay
+++ b/variants/arduino_giga_r1_stm32h747xx_m7/arduino_giga_r1_stm32h747xx_m7.overlay
@@ -465,6 +465,7 @@
 
 		builtin-led-gpios = <&gpioj 13 GPIO_ACTIVE_LOW>,
                         <&gpioi 12 GPIO_ACTIVE_LOW>,
+                        <&gpioj 13 GPIO_ACTIVE_LOW>,
                         <&gpioe 3 GPIO_ACTIVE_LOW>;
 
 		pwm-pin-gpios =	    <&gpioj 9 0>,

--- a/variants/arduino_opta_stm32h747xx_m7/arduino_opta_stm32h747xx_m7.overlay
+++ b/variants/arduino_opta_stm32h747xx_m7/arduino_opta_stm32h747xx_m7.overlay
@@ -87,8 +87,9 @@
 						<&gpiob 13 0>;  /* Modbus RE */
 
 		builtin-led-gpios = <&gpioh 12 0>,
-                        <&gpioe 5 0>,
-                        <&gpioh 11 0>;
+						<&gpioh 11 0>,
+						<&gpioh 12 0>,
+                        <&gpioe 5 0>;
 
 		adc-pin-gpios =	<&gpioz 0 0>,
 					<&gpioz 1 0>,

--- a/variants/arduino_portenta_c33_r7fa6m5bh3cfc/arduino_portenta_c33_r7fa6m5bh3cfc.overlay
+++ b/variants/arduino_portenta_c33_r7fa6m5bh3cfc/arduino_portenta_c33_r7fa6m5bh3cfc.overlay
@@ -269,6 +269,7 @@
 
 		builtin-led-gpios = <&ioport4 0 GPIO_ACTIVE_LOW>,
                         <&ioport1 7 GPIO_ACTIVE_LOW>,
+                        <&ioport4 0 GPIO_ACTIVE_LOW>,
                         <&ioport8 0 GPIO_ACTIVE_LOW>;
 
 		pwm-pin-gpios =	<&ioport6 0 0>;

--- a/variants/arduino_portenta_h7_stm32h747xx_m7/arduino_portenta_h7_stm32h747xx_m7.overlay
+++ b/variants/arduino_portenta_h7_stm32h747xx_m7/arduino_portenta_h7_stm32h747xx_m7.overlay
@@ -339,6 +339,7 @@ qspi_flash: &mx25l12833f {};
 
 		builtin-led-gpios = <&gpiok 6 0>,
 				    <&gpiok 5 0>,
+				    <&gpiok 6 0>,
 				    <&gpiok 7 0>;
 
 		pwm-pin-gpios =	<&gpioa 8 0>,


### PR DESCRIPTION
In ArduinoCore-zephyr\cores\arduino\Arduino.h, the built-in LED index was changed from 0 (RED) to 1 (GREEN).