### PR TITLE
loader: export symbols for Arduino_JSON library

### DIFF
--- a/loader/llext_exports.c
+++ b/loader/llext_exports.c
@@ -190,7 +190,6 @@ FORCE_EXPORT_SYM(close);
 FORCE_EXPORT_SYM(accept);
 FORCE_EXPORT_SYM(bind);
 FORCE_EXPORT_SYM(listen);
-EXPORT_SYMBOL(exit);
 FORCE_EXPORT_SYM(inet_pton);
 FORCE_EXPORT_SYM(sendto);
 FORCE_EXPORT_SYM(recvfrom);
@@ -235,6 +234,12 @@ EXPORT_SYMBOL(snprintf);
 EXPORT_SYMBOL(cbvprintf);
 FORCE_EXPORT_SYM(abort);
 EXPORT_SYMBOL(sscanf);
+EXPORT_SYMBOL(exit);
+FORCE_EXPORT_SYM(_exit);
+FORCE_EXPORT_SYM(__assert_no_args);
+EXPORT_SYMBOL(stdin);
+EXPORT_SYMBOL(stdout);
+EXPORT_SYMBOL(stderr);
 
 #if defined(CONFIG_RING_BUFFER)
 EXPORT_SYMBOL(ring_buf_get);
@@ -277,7 +282,6 @@ FORCE_EXPORT_SYM(__aeabi_dcmpge);
 
 #if defined (CONFIG_CPP)
 FORCE_EXPORT_SYM(__cxa_pure_virtual);
-FORCE_EXPORT_SYM(__assert_no_args);
 #endif
 
 #if defined(CONFIG_BOARD_ARDUINO_UNO_Q)

--- a/platform.txt
+++ b/platform.txt
@@ -17,13 +17,13 @@ compiler.warning_flags.all=-Wall -Wextra
 
 compiler.path={build.compiler_path}
 compiler.c.cmd={build.crossprefix}gcc
-compiler.c.flags=-g -c {compiler.warning_flags} {compiler.zephyr.macros} "@{compiler.zephyr.cflags_file}" -MMD -mcpu={build.mcu} {build.float-abi} {build.fpu}
+compiler.c.flags=-g -c {compiler.define} {compiler.warning_flags} {compiler.zephyr.macros} "@{compiler.zephyr.cflags_file}" -MMD -mcpu={build.mcu} {build.float-abi} {build.fpu}
 compiler.c.elf.cmd={build.crossprefix}g++
 compiler.c.elf.flags=-Wl,--gc-sections -mcpu={build.mcu} {build.float-abi} {build.fpu} -std=gnu++17
 compiler.S.cmd={build.crossprefix}g++
 compiler.S.flags=-c -x assembler-with-cpp -mcpu={build.mcu} {build.fpu}
 compiler.cpp.cmd={build.crossprefix}g++
-compiler.cpp.flags=-g -Os -std=gnu++17 -c {compiler.warning_flags} {compiler.zephyr.macros} "@{compiler.zephyr.cxxflags_file}" {compiler.zephyr.common_ldflags} {compiler.zephyr.extra_ldflags} {compiler.zephyr.common_cxxflags} {compiler.zephyr.extra_cxxflags} -MMD -mcpu={build.mcu} {build.float-abi} {build.fpu}
+compiler.cpp.flags=-g -Os -std=gnu++17 -c {compiler.define} {compiler.warning_flags} {compiler.zephyr.macros} "@{compiler.zephyr.cxxflags_file}" {compiler.zephyr.common_ldflags} {compiler.zephyr.extra_ldflags} {compiler.zephyr.common_cxxflags} {compiler.zephyr.extra_cxxflags} -MMD -mcpu={build.mcu} {build.float-abi} {build.fpu}
 compiler.ar.cmd={build.crossprefix}ar
 compiler.ar.flags=rcs
 compiler.objcopy.cmd=
@@ -34,7 +34,7 @@ compiler.elf2hex.cmd={build.crossprefix}objcopy
 compiler.ldflags=
 compiler.libraries.ldflags=
 compiler.size.cmd={build.crossprefix}size
-compiler.define=-DARDUINO=
+compiler.define=-D_PICOLIBC_CTYPE_SMALL=1
 
 compiler.zephyr.includes_file={build.variant.path}/includes.txt
 compiler.zephyr.cflags_file={build.variant.path}/cflags.txt


### PR DESCRIPTION
When running the Arduino_JSON library (https://github.com/arduino-libraries/Arduino_JSON), I encountered the error "llext: Undefined symbol with no entry in symbol table."
So I added the necessary symbols.