### PR TITLE
Arduino_LED_Matrix: add const to matrixWrite

### DIFF
--- a/libraries/Arduino_LED_Matrix/src/Arduino_LED_Matrix.h
+++ b/libraries/Arduino_LED_Matrix/src/Arduino_LED_Matrix.h
@@ -4,10 +4,10 @@
 extern "C" {
 void matrixBegin(void);
 void matrixEnd(void);
-void matrixPlay(uint8_t *buf, uint32_t len);
+void matrixPlay(const uint8_t *buf, uint32_t len);
 void matrixSetGrayscaleBits(uint8_t _max);
-void matrixGrayscaleWrite(uint8_t *buf);
-void matrixWrite(uint32_t *buf);
+void matrixGrayscaleWrite(const uint8_t *buf);
+void matrixWrite(const uint32_t *buf);
 };
 
 #if __has_include("ArduinoGraphics.h")

--- a/loader/matrix.inc
+++ b/loader/matrix.inc
@@ -163,12 +163,12 @@ static void timer_irq_handler_fn(const struct device *counter_dev, void *user_da
     i_isr = (i_isr + 1) % NUM_MATRIX_LEDS;
 }
 
-void matrixWrite(uint32_t* buf) {
+void matrixWrite(const uint32_t* buf) {
     memcpy(framebuffer, buf, NUM_MATRIX_LEDS/8);
     color = false;
 }
 
-void matrixGrayscaleWrite(uint8_t* buf) {
+void matrixGrayscaleWrite(const uint8_t* buf) {
     memcpy(framebuffer_color, buf, NUM_MATRIX_LEDS);
     color = true;
 }
@@ -201,7 +201,7 @@ void matrixEnd() {
 }
 
 
-void matrixPlay(uint8_t* buf, uint32_t len) {
+void matrixPlay(const uint8_t* buf, uint32_t len) {
     int i = 0;
     while (i < (len / 104)) {
 		matrixGrayscaleWrite(&buf[i*104]);


### PR DESCRIPTION
This allows you to then change the sketch(s) used within the test apps for the Q to use this header file with little changes to them.

Like the Weather forecast on LED matrix
```
#include "Arduino_LED_Matrix.h"
Arduino_LED_Matrix matrix;

void setup() {
  matrix.begin();
...
```

Or in my test app I also then included ArduinoGraphics
```
#include <Arduino_RouterBridge.h>
#include "ArduinoGraphics.h"
#include "Arduino_LED_Matrix.h"
...