### PR TITLE
trivial: unoq: specify reset gpio as push_pull

### DIFF
--- a/variants/arduino_uno_q_stm32u585xx/flash_bootloader.cfg
+++ b/variants/arduino_uno_q_stm32u585xx/flash_bootloader.cfg
@@ -1,4 +1,4 @@
-reset_config srst_only srst_push_pull
+reset_config srst_only srst_nogate srst_push_pull connect_assert_srst
 init
 reset
 halt

--- a/variants/arduino_uno_q_stm32u585xx/flash_sketch.cfg
+++ b/variants/arduino_uno_q_stm32u585xx/flash_sketch.cfg
@@ -1,4 +1,4 @@
-reset_config srst_only srst_push_pull
+reset_config srst_only srst_nogate srst_push_pull connect_assert_srst
 init
 reset
 halt


### PR DESCRIPTION
Completely specify the expected behaviour for reset pin on UNO Q, since the default fails in low power modes