### PR TITLE
Fix for analog inputs A5 A6 not working on Portenta C33

### DIFF
--- a/variants/arduino_portenta_c33_r7fa6m5bh3cfc/arduino_portenta_c33_r7fa6m5bh3cfc.overlay
+++ b/variants/arduino_portenta_c33_r7fa6m5bh3cfc/arduino_portenta_c33_r7fa6m5bh3cfc.overlay
@@ -136,7 +136,7 @@
 	};
 
 	a6: channel@e {
-		reg = <14>;
+		reg = <12>;
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
@@ -144,7 +144,7 @@
 	};
 
 	a5: channel@f {
-		reg = <15>;
+		reg = <13>;
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;


### PR DESCRIPTION
This PR fix the fact that analog inputs A5 and A6 appeared not working on Portenta C33 board