### PR TITLE
Portenta C33 ADC: fix for analog input A5 and A6 not working

### DIFF
--- a/variants/arduino_portenta_c33_r7fa6m5bh3cfc/arduino_portenta_c33_r7fa6m5bh3cfc.overlay
+++ b/variants/arduino_portenta_c33_r7fa6m5bh3cfc/arduino_portenta_c33_r7fa6m5bh3cfc.overlay
@@ -135,16 +135,16 @@
 		zephyr,resolution = <12>;
 	};
 
-	a6: channel@e {
-		reg = <14>;
+	a6: channel@c {
+		reg = <12>;
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 		zephyr,resolution = <12>;
 	};
 
-	a5: channel@f {
-		reg = <15>;
+	a5: channel@d {
+		reg = <13>;
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;


### PR DESCRIPTION
This PR fix the analog input A5 and A6 not working on Portenta C33