### PR TITLE
llext: add vsnprintf to exported symbols

### DIFF
--- a/loader/llext_exports.c
+++ b/loader/llext_exports.c
@@ -231,6 +231,7 @@ EXPORT_SYMBOL(printf);
 EXPORT_SYMBOL(sprintf);
 EXPORT_SYMBOL(snprintf);
 EXPORT_SYMBOL(cbvprintf);
+EXPORT_SYMBOL(vsnprintf);
 FORCE_EXPORT_SYM(abort);
 
 #if defined(CONFIG_RING_BUFFER)


### PR DESCRIPTION
vsnprintf is needed to compile Arduino_ConnectionHandler library