### PR TITLE
fix: SPI: improve compatibility with external libraries

### DIFF
--- a/libraries/SPI/SPI.cpp
+++ b/libraries/SPI/SPI.cpp
@@ -57,7 +57,7 @@ void arduino::ZephyrSPI::notUsingInterrupt(int interruptNumber) {
 }
 
 void arduino::ZephyrSPI::beginTransaction(SPISettings settings) {
-	uint32_t mode = 0;
+	uint32_t mode = SPI_HOLD_ON_CS;
 
 	// Set bus mode
 	switch (settings.getBusMode()) {


### PR DESCRIPTION
Adding `SPI_HOLD_ON_CS` ensures clock and data lines are not released until endOfTransaction()