### PR TITLE
nano_matter: Remove debug options from boards.txt

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -572,10 +572,6 @@ nano_matter.build.core=arduino
 nano_matter.build.crossprefix=arm-zephyr-eabi-
 nano_matter.build.compiler_path={runtime.tools.arm-zephyr-eabi-0.16.8.path}/bin/
 
-nano_matter.menu.debug.false=Standard
-nano_matter.menu.debug.true=Debug
-nano_matter.menu.debug.true.build.zsk_args.debug=-debug
-
 nano_matter.menu.link_mode.dynamic=Dynamic
 nano_matter.menu.link_mode.static=Static
 nano_matter.menu.link_mode.static.build.link_mode=static


### PR DESCRIPTION
Since the board do not have a cdc_acm peripheral the shell is not redirected and debug mode does nothing.