### PR TITLE
FIXME: disable additional_event_mask in NetworkInterface::begin()

### DIFF
--- a/libraries/SocketWrapper/SocketHelpers.cpp
+++ b/libraries/SocketWrapper/SocketHelpers.cpp
@@ -148,8 +148,11 @@ void NetworkInterface::setMACAddress(const uint8_t *mac) {
 
 int NetworkInterface::begin(bool blocking, uint64_t additional_event_mask) {
 	dhcp();
-	int ret = net_mgmt_event_wait_on_iface(netif, NET_EVENT_IPV4_ADDR_ADD | additional_event_mask,
-										   NULL, NULL, NULL, blocking ? K_FOREVER : K_SECONDS(1));
+	// FIXME: additional_event_mask cannot be ORed here due to how Zephyr
+	// events are handled internally. Must be reworked to wait on a sem
+	// and register multiple event masks with event_handler instead.
+	int ret = net_mgmt_event_wait_on_iface(netif, NET_EVENT_IPV4_ADDR_ADD, NULL, NULL, NULL,
+										   blocking ? K_FOREVER : K_SECONDS(1));
 	return (ret == 0) ? 1 : 0;
 }
 


### PR DESCRIPTION
This change addresses an issue where combining `additional_event_mask` with `NET_EVENT_IPV4_ADDR_ADD` in the `net_mgmt_event_wait_on_iface` function caused unexpected behavior due to Zephyr's internal event handling.

By isolating the wait to only `NET_EVENT_IPV4_ADDR_ADD`, we ensure that the function behaves as intended (and for all purposes, as it was before). A more robust solution involving semaphores and multiple event registrations will be implemented in the future.