### PR TITLE
core: serial: fix availableForWrite()

### DIFF
--- a/cores/arduino/zephyrSerial.cpp
+++ b/cores/arduino/zephyrSerial.cpp
@@ -126,9 +126,9 @@ int arduino::ZephyrSerial::available() {
 int arduino::ZephyrSerial::availableForWrite() {
 	int ret;
 
-	k_sem_take(&rx.sem, K_FOREVER);
-	ret = ring_buf_space_get(&rx.ringbuf);
-	k_sem_give(&rx.sem);
+	k_sem_take(&tx.sem, K_FOREVER);
+	ret = ring_buf_space_get(&tx.ringbuf);
+	k_sem_give(&tx.sem);
 
 	return ret;
 }


### PR DESCRIPTION
Hey y'all!
Found and fixed a bug while using the core:
`availableForWrite() was taking the free space of the Rx buffer instead of the Tx buffer.`
Happy holidays!