### PR TITLE
network: interfaces: end() method NetworkInterface

### DIFF
--- a/libraries/Ethernet/src/Ethernet.cpp
+++ b/libraries/Ethernet/src/Ethernet.cpp
@@ -76,10 +76,6 @@ EthernetHardwareStatus EthernetClass::hardwareStatus() {
 	}
 }
 
-void EthernetClass::end() {
-	disconnect();
-}
-
 void EthernetClass::setRetransmissionTimeout(uint16_t milliseconds) {
 	(void)milliseconds;
 }

--- a/libraries/Ethernet/src/Ethernet.h
+++ b/libraries/Ethernet/src/Ethernet.h
@@ -52,8 +52,6 @@ public:
 		return begin(nullptr, ip, dns, gateway, subnet);
 	}
 
-	void end(void);
-
 	void setRetransmissionTimeout(uint16_t milliseconds);
 	void setRetransmissionCount(uint8_t num);
 };

--- a/libraries/SocketWrapper/SocketHelpers.cpp
+++ b/libraries/SocketWrapper/SocketHelpers.cpp
@@ -156,6 +156,10 @@ int NetworkInterface::begin(bool blocking, uint64_t additional_event_mask) {
 	return (ret == 0) ? 1 : 0;
 }
 
+void NetworkInterface::end() {
+	disconnect();
+}
+
 bool NetworkInterface::disconnect() {
 	return (net_if_down(netif) == 0);
 }

--- a/libraries/SocketWrapper/SocketHelpers.h
+++ b/libraries/SocketWrapper/SocketHelpers.h
@@ -59,5 +59,6 @@ public:
 
 	int begin(bool blocking = true, uint64_t additional_event_mask = 0);
 
+	void end();
 	bool disconnect();
 };


### PR DESCRIPTION
Adding end() method in Network interface to preserve old behaviour in Arduino style defined network interfaces