### PR TITLE
llext: Add strnlen to exported symbols

### DIFF
--- a/cores/arduino/llext_wrappers.c
+++ b/cores/arduino/llext_wrappers.c
@@ -66,6 +66,7 @@
 W3(void *, memcpy, void *, const void *, size_t)
 W3(void *, memmove, void *, const void *, size_t)
 W1(size_t, strlen, const char *)
+W2(size_t, strnlen, const char *, size_t)
 W2(char *, strchr, const char *, int)
 W2(char *, strrchr, const char *, int)
 W2(char *, strstr, const char *, const char *)

--- a/loader/llext_exports.c
+++ b/loader/llext_exports.c
@@ -30,6 +30,7 @@ EXPORT_LIBC_SYM(strncpy);
 EXPORT_LIBC_SYM(strcasecmp);
 EXPORT_LIBC_SYM(strcmp);
 EXPORT_LIBC_SYM(strlen);
+EXPORT_LIBC_SYM(strnlen);
 EXPORT_LIBC_SYM(strchr);
 EXPORT_LIBC_SYM(strcat);
 


### PR DESCRIPTION
Previously, compilation of sketch programs that call [`strnlen`](https://man7.org/linux/man-pages/man3/strnlen.3.html) would fail:

```text
undefined reference to `strnlen'
```

The function is hereby made available for use in sketch programs.

---

Originally reported by @controllercustom:

https://forum.arduino.cc/t/the-strnlen-function-is-undefined-on-uno-q-zephyr/1430715

---

Related:

- https://github.com/arduino/ArduinoCore-zephyr/pull/280
- https://github.com/arduino/ArduinoCore-zephyr/pull/244
- https://github.com/arduino/ArduinoCore-renesas/issues/18