### PR TITLE
Arduino.h: Correct LED_BUILTIN define order

### DIFF
--- a/cores/arduino/Arduino.h
+++ b/cores/arduino/Arduino.h
@@ -42,8 +42,6 @@
 	DIGITAL_PIN_GPIOS_FIND_PIN(DT_REG_ADDR(DT_PHANDLE_BY_IDX(node, gpios, 0)),                     \
 							   DT_PHA_BY_IDX(node, gpios, 0, pin))
 
-#ifndef LED_BUILTIN
-
 /* Return the index of it if matched, oterwise return 0 */
 #define LED_BUILTIN_INDEX_BY_REG_AND_PINNUM(n, p, i, dev, num)                                     \
 	(DIGITAL_PIN_EXISTS(n, p, i, dev, num) ? i : 0)
@@ -62,7 +60,7 @@
 		  DT_PHA_BY_IDX(DT_PATH(zephyr_user), builtin_led_gpios, 0, pin)) > 0)
 #warning "pin not found in digital_pin_gpios"
 #else
-#define LED_BUILTIN                                                                                \
+#define ZARD_LED_BUILTIN                                                                           \
 	DIGITAL_PIN_GPIOS_FIND_PIN(                                                                    \
 		DT_REG_ADDR(DT_PHANDLE_BY_IDX(DT_PATH(zephyr_user), builtin_led_gpios, 0)),                \
 		DT_PHA_BY_IDX(DT_PATH(zephyr_user), builtin_led_gpios, 0, pin))
@@ -77,14 +75,12 @@
 									 DT_PHA_BY_IDX(DT_ALIAS(led0), gpios, 0, pin)) > 0)
 #warning "pin not found in digital_pin_gpios"
 #else
-#define LED_BUILTIN                                                                                \
+#define ZARD_LED_BUILTIN                                                                           \
 	DIGITAL_PIN_GPIOS_FIND_PIN(DT_REG_ADDR(DT_PHANDLE_BY_IDX(DT_ALIAS(led0), gpios, 0)),           \
 							   DT_PHA_BY_IDX(DT_ALIAS(led0), gpios, 0, pin))
 #endif
 
 #endif // builtin_led_gpios
-
-#endif // LED_BUILTIN
 
 #define DN_ENUMS(n, p, i) D##i = i
 
@@ -142,6 +138,11 @@ void analogReadResolution(int bits);
 void analogWriteResolution(int bits);
 
 #include <variant.h>
+
+#if !defined(LED_BUILTIN) && defined(ZARD_LED_BUILTIN)
+#define LED_BUILTIN ZARD_LED_BUILTIN
+#endif // LED_BUILTIN
+
 #ifdef __cplusplus
 #include <SerialUSB.h>
 #include <zephyrSerial.h>


### PR DESCRIPTION
Correct the order of LED_BUILTIN definitions so that board-specific definitions of LED_BUILTIN take precedence.