### PR TITLE
zephyrCommon: Change `delayMicroseconds` to busy loop

### DIFF
--- a/cores/arduino/zephyrCommon.cpp
+++ b/cores/arduino/zephyrCommon.cpp
@@ -280,7 +280,7 @@ void delay(unsigned long ms) {
 }
 
 void delayMicroseconds(unsigned int us) {
-	k_sleep(K_USEC(us));
+	k_busy_wait(us);
 }
 
 unsigned long micros(void) {


### PR DESCRIPTION
Since Arduino's `delayMicroseconds` is implemented as a busy loop, we change it to using `k_busy_wait` to improve compatibility.