### PR TITLE
cores: arduino: zephyrSerial: Add cast to suppress warning

### DIFF
--- a/cores/arduino/zephyrSerial.cpp
+++ b/cores/arduino/zephyrSerial.cpp
@@ -52,7 +52,7 @@ enum uart_config_data_bits conf_data_bits(uint16_t conf) {
 
 void arduino::ZephyrSerial::begin(unsigned long baud, uint16_t conf) {
 	struct uart_config config = {
-		.baudrate = baud,
+		.baudrate = static_cast<uint32_t>(baud),
 		.parity = conf_parity(conf),
 		.stop_bits = conf_stop_bits(conf),
 		.data_bits = conf_data_bits(conf),


### PR DESCRIPTION
There is no practical concern that the baud rate will exceed 32-bit size, so there is no problem with casting.