### PR TITLE
samples: hello_arduino: Correct printk format specifier

### DIFF
--- a/samples/hello_arduino/src/app.cpp
+++ b/samples/hello_arduino/src/app.cpp
@@ -16,14 +16,14 @@ void loop() {
   size_t ret2;
   ret1 = Serial.print(c);
   ret2 = Serial.println("Hello, World!");
-  printk("Sizes: %d %d\n", ret1, ret2);
+  printk("Sizes: %zu %zu\n", ret1, ret2);
   Serial.println();
   ret1 = Serial.print("My letter is: ");
   ret2 = Serial.println(c);
-  printk("Sizes: %d %d\n", ret1, ret2);
+  printk("Sizes: %zu %zu\n", ret1, ret2);
   Serial.println();
   char myString[] = "Will it print?";
   ret1 = Serial.println(myString);
-  printk("Size: %d \n\n\n", ret1);
+  printk("Size: %zu \n\n\n", ret1);
   delay(1000); // 1 second delay
 }


### PR DESCRIPTION
Fixed to use %zd which corresponds to size_t.

This will resolve the warning that occurs in 64-bit environments.