### PR TITLE
 zephyrCommon: Improve `pulseIn`

### DIFF
--- a/cores/arduino/zephyrCommon.cpp
+++ b/cores/arduino/zephyrCommon.cpp
@@ -485,12 +485,12 @@ unsigned long pulseIn(pin_size_t pinNumber, uint8_t state, unsigned long timeout
 	int64_t start, end, delta = 0;
 	const struct gpio_dt_spec *spec = &arduino_pins[pinNumber];
 
+	if (!gpio_is_ready_dt(spec)) {
+		return 0;
+	}
+
 	k_timer_init(&timer, NULL, NULL);
 	k_timer_start(&timer, K_MSEC(timeout), K_NO_WAIT);
-
-	if (!gpio_is_ready_dt(spec)) {
-		goto cleanup;
-	}
 
 	while (gpio_pin_get_dt(spec) == state && k_timer_status_get(&timer) == 0)
 		;


### PR DESCRIPTION
- Immediately terminate if GPIO not ready 

- Removing GPIO direction check
  Remove `#ifdef CONFIG_GPIO_GET_DIRECTION` guard to allow compilation on as many boards as possible.
  This allows this function to be executed even when the GPIO is set to OUTPUT,
  but it also matches the behavior of other core implementations, which simply do not detect pulses when the GPIO is set to OUTPUT.