### PR TITLE
ci: remove Ethernet examples from known issues list

### DIFF
--- a/variants/arduino_opta_stm32h747xx_m7/known_example_issues.txt
+++ b/variants/arduino_opta_stm32h747xx_m7/known_example_issues.txt
@@ -9,7 +9,4 @@
 # against the path of each sketch found in this repo. If a match is found, the
 # sketch compilation result will be ignored.
 
-# bug at core link time
-libraries/Ethernet/examples/UDPSendReceiveString
-libraries/Ethernet/examples/UdpNtpClient
 libraries/Storage/examples/FlashFormat

--- a/variants/arduino_portenta_c33_r7fa6m5bh3cfc/known_example_issues.txt
+++ b/variants/arduino_portenta_c33_r7fa6m5bh3cfc/known_example_issues.txt
@@ -11,7 +11,3 @@
 
 # needs porting the SE05X library from mbed
 libraries/Arduino_SecureElement/
-
-# bug at core link time
-libraries/Ethernet/examples/UDPSendReceiveString
-libraries/Ethernet/examples/UdpNtpClient

--- a/variants/arduino_portenta_h7_stm32h747xx_m7/known_example_issues.txt
+++ b/variants/arduino_portenta_h7_stm32h747xx_m7/known_example_issues.txt
@@ -9,7 +9,4 @@
 # against the path of each sketch found in this repo. If a match is found, the
 # sketch compilation result will be ignored.
 
-# bug at core link time
-libraries/Ethernet/examples/UDPSendReceiveString
-libraries/Ethernet/examples/UdpNtpClient
 libraries/Storage/examples/FlashFormat


### PR DESCRIPTION
PR arduino/ArduinoCore-zephyr#309 addressed the C++ issues that were causing the Ethernet examples to fail to link. With those fixes in place, these examples now compile (see the :interrobang: entries [here](https://github.com/arduino/ArduinoCore-zephyr/actions/runs/22069837492#user-content-zephyr_main), for example) and can be removed from the known issues list.
