### PR TITLE
UnoQ: Add Wire2 to A4/A5 pins

### DIFF
--- a/variants/arduino_uno_q_stm32u585xx/arduino_uno_q_stm32u585xx.overlay
+++ b/variants/arduino_uno_q_stm32u585xx/arduino_uno_q_stm32u585xx.overlay
@@ -22,6 +22,13 @@
 */
 };
 
+&i2c3 {
+	status = "okay";
+	pinctrl-0 = <&i2c3_scl_pc0 &i2c3_sda_pc1>;
+	pinctrl-names = "default"; 
+	clock-frequency = <I2C_BITRATE_FAST>;
+};
+
 /* clock from HSI48 */
 &mco1 {
 	status = "okay";
@@ -301,7 +308,7 @@
 					<&gpioc 0 0>;
 
 		serials = <&usart1>, <&lpuart1>;
-		i2cs = <&i2c2>, <&i2c4>;
+		i2cs = <&i2c2>, <&i2c4>, <&i2c3>;
 		spis = <&spi2>, <&spi3>;
 		/* PWM mapping for the digital pins  */
 		/* Currently only the pins marked with ~ on the pin headers are enabled */


### PR DESCRIPTION
resolves: #301 

Note: This adds these pins to a i2c3 device, which I added to the end of the list, so Wire2.  Unclear from other documentation
if there is some other SCL/SDA pins defined for the i2c3 device that there are plans for, like communication between processors

As these pins are shown as Wire pins on the official documents such as the pinout and multiple people have reported that it does not work.

However this has the effect of breaking the A4/A5 pins for Analog usage. This would be fixed if PR #269 or equivalent was
pulled in.

I tested a simple Wire Scanner sketch, which found a Sparkfun Qwiic button I connected to it.
```
*** Booting Zephyr OS build v4.2.0-42-gf737243623a0 ***

I2C Scanner

Scanning Wire...
No I2C devices found

Scanning Wire1...
Device found at address 0x3E  (unknown chip)
Device found at address 0x6F  (Qwiic Button)
done

Scanning Wire2...
Device found at address 0x6F  (Qwiic Button)
done

```

A simple analog test however failed, but I added a hack to it, to see if I set the moder back to 3 if it would work and it does.
That sketch:
```
void setup() {
  // put your setup code here, to run once:
  Serial.begin(115200);
  show_all_gpio_regs();
}

void loop() {
  // put your main code here, to run repeatedly:
  if (Serial.available()) {
    while (Serial.available()) {
      Serial.read();
      delay(200);
    }
    // force Analog mode PC0-1
    set_pin_moder(GPIOC, 0, 3);
    set_pin_moder(GPIOC, 1, 3);
    print_gpio_regs("C", (GPIO_TypeDef *)GPIOC_BASE);
  }
  Serial.print(analogRead(A4));
  Serial.print(" ");
  Serial.println(analogRead(A5));
  delay(1000);
}



void set_pin_moder(GPIO_TypeDef *port, uint8_t pin, uint8_t pin_mode) {
  // Set the MODER = could be done in fewer steps
  uint32_t moder = port->MODER;
  uint32_t mask = ~(0x3 << (pin * 2));
  moder = (moder & mask) | (pin_mode << (pin * 2));
  port->MODER = moder;
}

void set_gpio_pin_mode(GPIO_TypeDef *port, uint8_t pin, uint8_t af) {
  // Set the MODER = could be done in fewer steps
  uint32_t moder = port->MODER;
  uint32_t mask = ~(0x3 << (pin * 2));
  moder = (moder & mask) | (0x2 << (pin * 2));
  port->MODER = moder;

  if (pin < 8) {
    port->AFR[0] = port->AFR[0] & ~(0xf << (pin * 4)) | (af << (pin * 4));
  } else {
    pin -= 8;
    port->AFR[1] = port->AFR[1] & ~(0xf << (pin * 4)) | (af << (pin * 4));
  }
}

void print_gpio_regs(const char *name, GPIO_TypeDef *port) {
  //printk("GPIO%s(%p) %08X %08X %08x\n", name, port, port->MODER, port->AFR[0], port->AFR[1]);
  Serial.print("GPIO");
  Serial.print(name);
  Serial.print(" ");
  uint32_t moder = port->MODER;
  Serial.print(moder, HEX);
  Serial.print(" : ");
  for (uint8_t i = 0; i < 16; i++) {
    switch (moder & 0xC0000000) {
      case 0x00000000ul: Serial.print("I"); break;
      case 0x40000000ul: Serial.print("O"); break;
      case 0x80000000ul: Serial.print("F"); break;
      default: Serial.print("A"); break;
    }
    moder <<= 2;
  }
  Serial.print(" ");
  Serial.print(port->AFR[0], HEX);
  Serial.print(" ");
  Serial.print(port->AFR[1], HEX);
  Serial.print(" ");
  Serial.print(port->IDR, HEX);
  Serial.print(" ");
  Serial.print(port->ODR, HEX);
  Serial.print(" ");
  uint32_t pupdr = port->PUPDR;
  Serial.print(pupdr, HEX);
  Serial.print(" : ");
  for (uint8_t i = 0; i < 16; i++) {
    switch (pupdr & 0xC0000000) {
      case 0x00000000ul: Serial.print("-"); break;
      case 0x40000000ul: Serial.print("U"); break;
      case 0x80000000ul: Serial.print("D"); break;
      default: Serial.print("?"); break;
    }
    pupdr <<= 2;
  }
  Serial.println();
}

void show_all_gpio_regs() {
  print_gpio_regs("A", (GPIO_TypeDef *)GPIOA_BASE);
  print_gpio_regs("B", (GPIO_TypeDef *)GPIOB_BASE);
  print_gpio_regs("C", (GPIO_TypeDef *)GPIOC_BASE);
  print_gpio_regs("D", (GPIO_TypeDef *)GPIOD_BASE);
  print_gpio_regs("E", (GPIO_TypeDef *)GPIOE_BASE);
  print_gpio_regs("F", (GPIO_TypeDef *)GPIOF_BASE);
  print_gpio_regs("G", (GPIO_TypeDef *)GPIOG_BASE);
  print_gpio_regs("H", (GPIO_TypeDef *)GPIOH_BASE);
  print_gpio_regs("I", (GPIO_TypeDef *)GPIOI_BASE);
}
```
And a run from this sketch where after a bit I hit CR to force the moder
```
*** Booting Zephyr OS build v4.2.0-42-gf737243623a0 ***
GPIOA ABBEFFDF : FFFAFAAFAAAAAOAA 0 1000 C000 0 64000000 : UDU-------------
GPIOB ABAAAABA : FFFAFFFFFFFFFAFF 77600022 55504422 ED0 0 A8505900 : DDD-UU--UUDU----
GPIOC FFFFFFFA : AAAAAAAAAAAAAAFF 44 0 2 0 5 : --------------UU
GPIOD FAFFFFFF : AAFFAAAAAAAAAAAA 0 440000 3000 0 5000000 : --UU------------
GPIOE FFFFFFFF : AAAAAAAAAAAAAAAA 0 0 0 0 0 : ----------------
GPIOF FFFFFFFF : AAAAAAAAAAAAAAAA 0 0 0 0 0 : ----------------
GPIOG F2EAABFF : AAIFAFFFFFFAAAAA 88800000 60668 3580 0 9294400 : --DU-DDUU-U-----
GPIOH FEAFFFFF : AAAFFFAAAAAAAAAA 0 22200 400 0 0 : ----------------
GPIOI FFFF : IIIIIIIIAAAAAAAA 0 0 0 0 0 : ----------------
21 92
20 98
20 98
20 98
21 98
20 98
20 98
20 98
21 98
20 98
18 96
20 98
20 98
19 98
GPIOC FFFFFFFF : AAAAAAAAAAAAAAAA 44 0 0 0 5 : --------------UU
572 476
108 476
109 477
108 476
108 476
107 477
107 257
106 0
107 587
107 844
106 1023
107 1023
106 1023
```
