### PR TITLE
llext: adding missing time and math functions export

### DIFF
--- a/cores/arduino/llext_wrappers.c
+++ b/cores/arduino/llext_wrappers.c
@@ -135,6 +135,7 @@ W1(float, tanf, float)
 /* math.h - double(double, double) */
 W2(double, atan2, double, double)
 W2(double, pow, double, double)
+W2(double, ldexp, double, double)
 
 /* math.h - float(float, float) */
 W2(float, atan2f, float, float)

--- a/loader/llext_exports.c
+++ b/loader/llext_exports.c
@@ -92,6 +92,7 @@ EXPORT_LIBC_SYM(sqrt);
 EXPORT_LIBC_SYM(sqrtf);
 EXPORT_LIBC_SYM(tan);
 EXPORT_LIBC_SYM(tanf);
+EXPORT_LIBC_SYM(ldexp);
 
 // stdio.h
 EXPORT_LIBC_SYM(puts);


### PR DESCRIPTION
added `time`, `sys_clock_settime` and `ldexp` export. This PR is required for zephyr IotCloud integration.