### PR TITLE
zephyrSerial: provide ARDUINO_ROUTER_SERIAL from DTS

### DIFF
--- a/cores/arduino/Arduino.h
+++ b/cores/arduino/Arduino.h
@@ -160,4 +160,8 @@ void analogWriteResolution(int bits);
 // Allow namespace-less operations if Arduino.h is included
 using namespace arduino;
 
+#if __has_include("postvariant.h")
+#include "postvariant.h"
+#endif
+
 #endif // __cplusplus

--- a/cores/arduino/DebugLog.h
+++ b/cores/arduino/DebugLog.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Arduino s.r.l. and/or its affiliated companies
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+/*
+ * This header is used to forcibly disable logging and assertions in the
+ * MsgPack library. It is here to shadow the real DebugLog library available in
+ * the index, which is currently not compatible with the latest boards.
+ */
+
+#define LOG_ERROR(...) ((void)0)
+#define LOG_WARN(...)  ((void)0)
+#define LOG_INFO(...)  ((void)0)
+#define LOG_DEBUG(...) ((void)0)
+#define LOG_TRACE(...) ((void)0)
+#define ASSERT(...)    ((void)0)
+#define ASSERTM(...)   ((void)0)
+#define PRINT(...)     ((void)0)
+#define PRINTLN(...)   ((void)0)

--- a/cores/arduino/SerialUSB.h
+++ b/cores/arduino/SerialUSB.h
@@ -57,7 +57,6 @@ private:
 };
 } // namespace arduino
 
-#if (DT_NODE_HAS_PROP(DT_PATH(zephyr_user), cdc_acm) &&                                            \
-	 (CONFIG_USB_CDC_ACM || CONFIG_USBD_CDC_ACM_CLASS))
+#if ZARD_FIRST_SERIAL_IS_SERIALUSB
 extern arduino::SerialUSB_ Serial;
 #endif

--- a/cores/arduino/USB.cpp
+++ b/cores/arduino/USB.cpp
@@ -10,10 +10,9 @@
 #include <zephyr/usb/usb_device.h>
 #include <SerialUSB.h>
 
-#if ((DT_NODE_HAS_PROP(DT_PATH(zephyr_user), cdc_acm)) &&                                          \
-	 (CONFIG_USB_CDC_ACM || CONFIG_USBD_CDC_ACM_CLASS))
+#if ZARD_FIRST_SERIAL_IS_SERIALUSB
 const struct device *const usb_dev =
-	DEVICE_DT_GET(DT_PHANDLE_BY_IDX(DT_PATH(zephyr_user), cdc_acm, 0));
+	DEVICE_DT_GET(DT_PHANDLE_BY_IDX(DT_PATH(zephyr_user), cdc_acm_serial, 0));
 
 void __attribute__((weak)) _on_1200_bps() {
 	NVIC_SystemReset();

--- a/cores/arduino/main.cpp
+++ b/cores/arduino/main.cpp
@@ -24,8 +24,7 @@ void __attribute__((weak)) __loopHook(void) {
 }
 
 int main(void) {
-#if (DT_NODE_HAS_PROP(DT_PATH(zephyr_user), cdc_acm) &&                                            \
-	 (CONFIG_USB_CDC_ACM || CONFIG_USBD_CDC_ACM_CLASS))
+#if ZARD_FIRST_SERIAL_IS_SERIALUSB
 	Serial.begin(115200);
 #endif
 

--- a/cores/arduino/zephyrSerial.cpp
+++ b/cores/arduino/zephyrSerial.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022 Dhruva Gole
+ * Copyright (c) Arduino s.r.l. and/or its affiliated companies
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -189,62 +190,29 @@ void arduino::ZephyrSerial::flush() {
 	}
 }
 
-#if (DT_NODE_HAS_PROP(DT_PATH(zephyr_user), cdc_acm))
-#define FIRST_UART_INDEX 1
-#else
-#define FIRST_UART_INDEX 0
-#endif
-
 #if DT_NODE_HAS_PROP(DT_PATH(zephyr_user), serials)
-#if !(DT_NODE_HAS_PROP(DT_PATH(zephyr_user), cdc_acm) &&                                           \
-	  (CONFIG_USB_CDC_ACM || CONFIG_USBD_CDC_ACM_CLASS))
-// If CDC USB, use that object as Serial (and SerialUSB)
-arduino::ZephyrSerial
-	Serial(DEVICE_DT_GET(DT_PHANDLE_BY_IDX(DT_PATH(zephyr_user), serials, FIRST_UART_INDEX)));
+#define DEFINE_SERIAL_N(n, p, i)                                                                   \
+	arduino::ZephyrSerial ZARD_SERIAL_NAME(i)(DEVICE_DT_GET(DT_PHANDLE_BY_IDX(n, p, i)));
+DT_FOREACH_PROP_ELEM(DT_PATH(zephyr_user), serials, DEFINE_SERIAL_N)
+
+#elif DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(arduino_serial))
+arduino::ZephyrSerial ZARD_SERIAL_NAME(0)(DEVICE_DT_GET(DT_NODELABEL(arduino_serial)));
 #endif
-#if (DT_PROP_LEN(DT_PATH(zephyr_user), serials) > 1)
-#define ARDUINO_SERIAL_DEFINED_0 1
 
-#define DECL_SERIAL_0(n, p, i)
-#define DECL_SERIAL_N(n, p, i)                                                                     \
-	arduino::ZephyrSerial Serial##i(DEVICE_DT_GET(DT_PHANDLE_BY_IDX(n, p, i)));
-#define DECLARE_SERIAL_N(n, p, i)                                                                  \
-	COND_CODE_1(ARDUINO_SERIAL_DEFINED_##i, (DECL_SERIAL_0(n, p, i)), (DECL_SERIAL_N(n, p, i)))
-
-#define CALL_EVENT_0(n, p, i)
-#define CALL_EVENT_N(n, p, i)                                                                      \
-	if (_CONCAT(Serial, i).available())                                                            \
-		_CONCAT(_CONCAT(serial, i), Event)();
-#define CALL_SERIALEVENT_N(n, p, i)                                                                \
-	COND_CODE_1(ARDUINO_SERIAL_DEFINED_##i, (CALL_EVENT_0(n, p, i)), (CALL_EVENT_N(n, p, i)));
-
-#define DECL_EVENT_0(n, p, i)
-#define DECL_EVENT_N(n, p, i)                                                                      \
-	__attribute__((weak)) void serial##i##Event() {                                                \
-	}
-#define DECLARE_SERIALEVENT_N(n, p, i)                                                             \
-	COND_CODE_1(ARDUINO_SERIAL_DEFINED_##i, (DECL_EVENT_0(n, p, i)), (DECL_EVENT_N(n, p, i)));
-
-DT_FOREACH_PROP_ELEM(DT_PATH(zephyr_user), serials, DECLARE_SERIAL_N)
-#endif // PROP_LEN(serials) > 1
-#elif DT_NODE_HAS_STATUS(DT_NODELABEL(arduino_serial), okay)
-/* If serials node is not defined, tries to use arduino_serial */
-arduino::ZephyrSerial Serial(DEVICE_DT_GET(DT_NODELABEL(arduino_serial)));
-#else
+#if ZARD_FIRST_SERIAL_IS_STUB
 arduino::ZephyrSerialStub Serial;
 #endif
 
-__attribute__((weak)) void serialEvent() {
-}
-#if (DT_PROP_LEN(DT_PATH(zephyr_user), serials) > 1)
-DT_FOREACH_PROP_ELEM(DT_PATH(zephyr_user), serials, DECLARE_SERIALEVENT_N)
-#endif
+#define DEFINE_WEAK_SERIALEVENT_N(n, s)                                                            \
+	__attribute__((weak)) void CONCAT(serial, ZARD_SERIAL_STEM(n), Event)() {                      \
+	}
+
+#define CALL_SERIALEVENT_N(n, s)                                                                   \
+	if (ZARD_SERIAL_NAME(n).available())                                                           \
+		CONCAT(serial, ZARD_SERIAL_STEM(n), Event)();
+
+LISTIFY(ZARD_GENERIC_SERIAL_COUNT, DEFINE_WEAK_SERIALEVENT_N, ())
 
 void arduino::serialEventRun(void) {
-	if (Serial.available()) {
-		serialEvent();
-	}
-#if (DT_PROP_LEN(DT_PATH(zephyr_user), serials) > 1)
-	DT_FOREACH_PROP_ELEM(DT_PATH(zephyr_user), serials, CALL_SERIALEVENT_N)
-#endif
+	LISTIFY(ZARD_GENERIC_SERIAL_COUNT, CALL_SERIALEVENT_N, ())
 }

--- a/cores/arduino/zephyrSerial.h
+++ b/cores/arduino/zephyrSerial.h
@@ -116,6 +116,22 @@ protected:
 
 } // namespace arduino
 
+/* Return the index of it if matched, oterwise return an empty string. */
+#define ZARD_SERIAL_MATCH(n, p, i, node)                                                           \
+	COND_CODE_1(DT_SAME_NODE(DT_PHANDLE_BY_IDX(n, p, i), node), (i), ())
+
+/* Only matched device returns non-empty value, so the overall expansion is
+ * matched device's index.
+ */
+#define ZARD_SERIAL_INDEXOF(node)                                                                  \
+	DT_FOREACH_PROP_ELEM_VARGS(DT_PATH(zephyr_user), serials, ZARD_SERIAL_MATCH, node)
+
+/* Serial object associated with the Zephyr console. */
+#define ARDUINO_CONSOLE_SERIAL ZARD_SERIAL_NAME(ZARD_SERIAL_INDEXOF(DT_CHOSEN(zephyr_console)))
+
+/* Serial object associated with the first HW serial (usually on D0/D1). */
+#define ARDUINO_HARDWARE_SERIAL ZARD_SERIAL_NAME(0)
+
 #if DT_NODE_HAS_PROP(DT_PATH(zephyr_user), cdc_acm_serial)
 /* Devicetree requires a SerialUSB object for 'Serial'. */
 #define ZARD_SKIP_FIRST_SERIAL 1

--- a/cores/arduino/zephyrSerial.h
+++ b/cores/arduino/zephyrSerial.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022 Dhruva Gole
+ * Copyright (c) Arduino s.r.l. and/or its affiliated companies
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -115,26 +116,63 @@ protected:
 
 } // namespace arduino
 
-#if DT_NODE_HAS_PROP(DT_PATH(zephyr_user), serials)
-#if !(DT_NODE_HAS_PROP(DT_PATH(zephyr_user), cdc_acm) &&                                           \
-	  (CONFIG_USB_CDC_ACM || CONFIG_USBD_CDC_ACM_CLASS))
-// If CDC USB, use that object as Serial (and SerialUSB)
-extern arduino::ZephyrSerial Serial;
-#endif
-#if (DT_PROP_LEN(DT_PATH(zephyr_user), serials) > 1)
-#define SERIAL_DEFINED_0                 1
-#define EXTERN_SERIAL_N(i)               extern arduino::ZephyrSerial Serial##i;
-#define DECLARE_EXTERN_SERIAL_N(n, p, i) COND_CODE_1(SERIAL_DEFINED_##i, (), (EXTERN_SERIAL_N(i)))
-
-/* Declare Serial1, Serial2, ... */
-DT_FOREACH_PROP_ELEM(DT_PATH(zephyr_user), serials, DECLARE_EXTERN_SERIAL_N)
-
-#undef DECLARE_EXTERN_SERIAL_N
-#undef EXTERN_SERIAL_N
-#undef SERIAL_DEFINED_0
-#endif
-#elif DT_NODE_HAS_STATUS(DT_NODELABEL(arduino_serial), okay)
-extern arduino::ZephyrSerial Serial;
+#if DT_NODE_HAS_PROP(DT_PATH(zephyr_user), cdc_acm_serial)
+/* Devicetree requires a SerialUSB object for 'Serial'. */
+#define ZARD_SKIP_FIRST_SERIAL 1
+#if (CONFIG_USB_CDC_ACM || CONFIG_USBD_CDC_ACM_CLASS)
+/* SerialUSB can be compiled in the project. */
+#define ZARD_FIRST_SERIAL_IS_SERIALUSB 1
 #else
+/* SerialUSB is required but no driver was enabled for the USB CDC ACM device.
+ * Define a stub Serial object to avoid build errors.
+ */
+#define ZARD_FIRST_SERIAL_IS_STUB 1
+#endif
+#endif
+
+/* Name of a Serial object for a given index. */
+#define ZARD_SERIAL_NAME(n) CONCAT(Serial, ZARD_SERIAL_STEM(n))
+
+/*
+ * Determine the number of generic ZephyrSerial objects to instantiate.
+ */
+
+#if DT_NODE_HAS_PROP(DT_PATH(zephyr_user), serials)
+/* The array property; the total number is the length of the array. */
+#define ZARD_GENERIC_SERIAL_COUNT DT_PROP_LEN(DT_PATH(zephyr_user), serials)
+
+#elif DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(arduino_serial))
+/* A single node with compatible "arduino,serial" is present. */
+#define ZARD_GENERIC_SERIAL_COUNT 1
+
+#elif ZARD_SKIP_FIRST_SERIAL
+/* Only a special Serial is present. */
+#define ZARD_GENERIC_SERIAL_COUNT 0
+
+#else
+/* Neither 'serials' property, nor 'arduino,serial' node, nor a special Serial
+ * is present. Define a stub Serial object to avoid build errors.
+ */
+#define ZARD_GENERIC_SERIAL_COUNT 0
+#define ZARD_SKIP_FIRST_SERIAL    1
+#define ZARD_FIRST_SERIAL_IS_STUB 1
+#endif
+
+#if ZARD_SKIP_FIRST_SERIAL
+// Map index 0 to 'Serial1', index 1 to 'Serial2', etc.
+#define ZARD_SERIAL_STEM(i) UTIL_INC(i)
+#else
+// Map index 0 to 'Serial', index 1 to 'Serial1', etc.
+#define ZARD_SERIAL_STEM(i) COND_CODE_0(i, (), (i))
+#endif
+
+#if ZARD_FIRST_SERIAL_IS_STUB
 extern arduino::ZephyrSerialStub Serial;
+#endif
+
+#if ZARD_GENERIC_SERIAL_COUNT > 0
+/* Declare all generic ZephyrSerial objects */
+#define DECLARE_SERIAL_N(n, s) extern arduino::ZephyrSerial ZARD_SERIAL_NAME(n);
+LISTIFY(ZARD_GENERIC_SERIAL_COUNT, DECLARE_SERIAL_N, ())
+#undef DECLARE_SERIAL_N
 #endif

--- a/cores/arduino/zephyrSerial.h
+++ b/cores/arduino/zephyrSerial.h
@@ -146,6 +146,17 @@ protected:
 #endif
 #endif
 
+#if DT_NODE_HAS_PROP(DT_PATH(zephyr_user), arduino_router_serial)
+/* If the board has an arduino,router-serial node, and the currently used
+ * library has the support, then the 'Serial' object is actually the same as
+ * the Monitor object in the Arduino_RouterBridge library.
+ */
+#define ZARD_SKIP_FIRST_SERIAL              1
+#define ZARD_FIRST_SERIAL_IS_ARDUINO_ROUTER 1
+#define ARDUINO_ROUTER_PHANDLE              DT_PROP(DT_PATH(zephyr_user), arduino_router_serial)
+#define ARDUINO_ROUTER_SERIAL               ZARD_SERIAL_NAME(ZARD_SERIAL_INDEXOF(ARDUINO_ROUTER_PHANDLE))
+#endif
+
 /* Name of a Serial object for a given index. */
 #define ZARD_SERIAL_NAME(n) CONCAT(Serial, ZARD_SERIAL_STEM(n))
 

--- a/extra/artifacts/zephyr_unoq.only
+++ b/extra/artifacts/zephyr_unoq.only
@@ -4,4 +4,7 @@
 # Files listed here are included by this package only, and automatically
 # excluded by all other artifacts.
 
+# Shadow the actual DebugLog library which does not work on the UNO Q
+cores/arduino/DebugLog.h
+
 libraries/Arduino_LED_Matrix/

--- a/libraries/stubs/Arduino_RouterBridge.h
+++ b/libraries/stubs/Arduino_RouterBridge.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) Arduino s.r.l. and/or its affiliated companies
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+/*
+ * This is just a placeholder to handle the case of the Arduino_RouterBridge
+ * library NOT being installed. If this file is chosen, the actual library is
+ * missing and the user needs to be warned about it.
+ */
+
+#error                                                                                             \
+	"Please install the Arduino_RouterBridge library from the Library Manager for proper Serial support on this board."

--- a/variants/arduino_giga_r1_stm32h747xx_m7/arduino_giga_r1_stm32h747xx_m7.overlay
+++ b/variants/arduino_giga_r1_stm32h747xx_m7/arduino_giga_r1_stm32h747xx_m7.overlay
@@ -522,8 +522,8 @@
 					<&gpioa 4 0>,
 					<&gpioa 5 0>;
 
-		serials = <&board_cdc_acm_uart>, <&usart1>, <&usart2>, <&uart4>, <&usart6>;
-		cdc-acm = <&board_cdc_acm_uart>;
+		cdc-acm-serial = <&board_cdc_acm_uart>; /* 'Serial' object is managed by SerialUSB */
+		serials = <&usart1>, <&usart2>, <&uart4>, <&usart6>; /* 'Serial1' onwards */
 		cans = <&fdcan2>;
 		i2cs = <&i2c2>, <&i2c4>, <&i2c1>;
 		spis = <&spi1>, <&spi5>;

--- a/variants/arduino_nano_33_ble_nrf52840_sense/arduino_nano_33_ble_nrf52840_sense.overlay
+++ b/variants/arduino_nano_33_ble_nrf52840_sense/arduino_nano_33_ble_nrf52840_sense.overlay
@@ -135,8 +135,8 @@
 				<&adc 4>,
 				<&adc 1>;
 
-		serials = <&board_cdc_acm_uart>, <&uart0>;
-		cdc-acm = <&board_cdc_acm_uart>;
+		cdc-acm-serial = <&board_cdc_acm_uart>; /* 'Serial' object is managed by SerialUSB */
+		serials = <&uart0>; /* 'Serial1' onwards */
 		i2cs = <&arduino_nano_i2c>, <&i2c1>;
 	};
 };

--- a/variants/arduino_opta_stm32h747xx_m7/arduino_opta_stm32h747xx_m7.overlay
+++ b/variants/arduino_opta_stm32h747xx_m7/arduino_opta_stm32h747xx_m7.overlay
@@ -119,8 +119,8 @@
 					<&gpiof 6 0>,
 					<&gpiof 4 0>;
 
-		serials = <&board_cdc_acm_uart>, <&usart3>, <&usart6>;
-		cdc-acm = <&board_cdc_acm_uart>;
+		cdc-acm-serial = <&board_cdc_acm_uart>; /* 'Serial' object is managed by SerialUSB */
+		serials = <&usart3>, <&usart6>; /* 'Serial1' onwards */
 		i2cs = <&i2c3>, <&i2c1>;
 
 		io-channels =	<&adc1 0>,

--- a/variants/arduino_portenta_c33_r7fa6m5bh3cfc/arduino_portenta_c33_r7fa6m5bh3cfc.overlay
+++ b/variants/arduino_portenta_c33_r7fa6m5bh3cfc/arduino_portenta_c33_r7fa6m5bh3cfc.overlay
@@ -302,8 +302,8 @@
 
 		pwm-pin-gpios =	<&ioport6 0 0>;
 
-		serials = <&board_cdc_acm_uart>, <&uart9>, <&uart7>, <&uart6>, <&uart5>;
-		cdc-acm = <&board_cdc_acm_uart>;
+		cdc-acm-serial = <&board_cdc_acm_uart>; /* 'Serial' object is managed by SerialUSB */
+		serials = <&uart9>, <&uart7>, <&uart6>, <&uart5>; /* 'Serial1' onwards */
 		i2cs = <&iic0>, <&iic1>, <&i2c3>;
 		spis = <&spi1>;
 		pwms = <&pwm6 1 PWM_HZ(25000000) PWM_POLARITY_NORMAL>;

--- a/variants/arduino_portenta_h7_stm32h747xx_m7/arduino_portenta_h7_stm32h747xx_m7.overlay
+++ b/variants/arduino_portenta_h7_stm32h747xx_m7/arduino_portenta_h7_stm32h747xx_m7.overlay
@@ -389,8 +389,8 @@ qspi_flash: &mx25l12833f {};
 				<&gpioz 4 0>,			/* Hack for D19  */
 				<&gpioz 5 0>;			/* Hack for D20 */
 
-		serials = <&board_cdc_acm_uart>,<&usart6>, <&usart1>, <&uart4>;
-		cdc-acm = <&board_cdc_acm_uart>;
+		cdc-acm-serial = <&board_cdc_acm_uart>; /* 'Serial' object is managed by SerialUSB */
+		serials = <&usart6>, <&usart1>, <&uart4>; /* 'Serial1' onwards */
 		i2cs = <&i2c3>, <&i2c1>, <&i2c4>;
 		spis = <&spi2>;
 		cans = <&fdcan1>;

--- a/variants/arduino_uno_q_stm32u585xx/arduino_uno_q_stm32u585xx.overlay
+++ b/variants/arduino_uno_q_stm32u585xx/arduino_uno_q_stm32u585xx.overlay
@@ -328,6 +328,7 @@
 					<&gpioc 1 0>,
 					<&gpioc 0 0>;
 
+		arduino,router-serial = <&lpuart1>; /* 'Serial' is provided by the Monitor */
 		serials = <&usart1>, <&lpuart1>;
 		cans = <&fdcan1>;
 		i2cs = <&i2c2>, <&i2c4>, <&i2c3>;

--- a/variants/arduino_uno_q_stm32u585xx/postvariant.h
+++ b/variants/arduino_uno_q_stm32u585xx/postvariant.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Arduino s.r.l. and/or its affiliated companies
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+/* This dance is necessary to force the inclusion of "Arduino_RouterBridge.h"
+ * during the library discovery phase, so that the library include path is
+ * added to the sketch build process.
+ *
+ * This will "discover" the stub in the libraries/stubs/ folder if the library
+ * is not installed, and the actual header if it is.
+ */
+
+#if ARDUINO_LIBRARY_DISCOVERY_PHASE
+#include "Arduino_RouterBridge.h"
+#else
+#if __has_include("Arduino_RouterBridge.h")
+#include "Arduino_RouterBridge.h"
+#endif
+#endif

--- a/variants/arduino_uno_q_stm32u585xx/variant.h
+++ b/variants/arduino_uno_q_stm32u585xx/variant.h
@@ -1,8 +1,19 @@
 /*
  * Copyright (c) 2022 Dhruva Gole
+ * Copyright (c) Arduino s.r.l. and/or its affiliated companies
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+#if !ARDUINO_LIBRARY_DISCOVERY_PHASE
+#if __has_include("Arduino_RouterBridge.h")
+#if __has_include("routerbridge_provides_serial.h")
+#define ARDUINO_ROUTERBRIDGE_PROVIDES_SERIAL
+#else
+#error "Please update the Arduino_RouterBridge library to the latest version to ensure Serial support on this board."
+#endif
+#endif
+#endif
 
 // TODO: correctly handle these legacy defines
 #define MOSI    0

--- a/variants/frdm_mcxn947_mcxn947_cpu0/frdm_mcxn947_mcxn947_cpu0.overlay
+++ b/variants/frdm_mcxn947_mcxn947_cpu0/frdm_mcxn947_mcxn947_cpu0.overlay
@@ -28,8 +28,8 @@
 	zephyr,user {
 		digital-pin-gpios = <&gpio0 10 GPIO_ACTIVE_LOW>, <&gpio0 27 GPIO_ACTIVE_LOW>, <&gpio1 2 GPIO_ACTIVE_LOW>;
 		builtin-led-gpios = <&gpio0 10 GPIO_ACTIVE_LOW>, <&gpio0 27 GPIO_ACTIVE_LOW>, <&gpio1 2 GPIO_ACTIVE_LOW>;
-		serials = <&board_cdc_acm_uart>, <&flexcomm4_lpuart4>;
-		cdc-acm = <&board_cdc_acm_uart>;
+		cdc-acm-serial = <&board_cdc_acm_uart>; /* 'Serial' object is managed by SerialUSB */
+		serials = <&flexcomm4_lpuart4>; /* 'Serial1' onwards */
 		i2cs = <&flexcomm2_lpi2c2>;
 		spis = <&flexcomm1_lpspi1>;
 	};

--- a/variants/frdm_rw612_rw612/frdm_rw612_rw612.overlay
+++ b/variants/frdm_rw612_rw612/frdm_rw612_rw612.overlay
@@ -26,8 +26,7 @@
 	zephyr,user {
 		digital-pin-gpios = <&hsgpio0 12 GPIO_ACTIVE_LOW>;
 		builtin-led-gpios = <&hsgpio0 12 GPIO_ACTIVE_LOW>;
-		serials = <&board_cdc_acm_uart>;
-		cdc-acm = <&board_cdc_acm_uart>;
+		cdc-acm-serial = <&board_cdc_acm_uart>; /* 'Serial' object is managed by SerialUSB */
 		i2cs = <&arduino_i2c>;
 		spis = <&flexcomm1>;
 	};


### PR DESCRIPTION
This PR tries to provide an `ARDUINO_ROUTER_SERIAL` #define for the Arduino UNO Q from the DeviceTree Zephyr code, to be used to customize the library compilation stage and allow `Serial` to be exported to sketches.

Requires:
- [x] https://github.com/arduino-libraries/Arduino_RouterBridge/pull/57
- [x]  https://github.com/arduino-libraries/ArduinoRS485/pull/73
- [x] https://github.com/arduino-libraries/ArduinoBLE/pull/428

~DNM until above PRs are merged and the last 'wip' commit is removed.~ EDIT: Blocker PRs merged!