### PR TITLE
cores: arduino: Improve analog(Read|Write)Rsolution declaration

### DIFF
--- a/cores/arduino/Arduino.h
+++ b/cores/arduino/Arduino.h
@@ -134,8 +134,9 @@ int digitalPinToInterrupt(pin_size_t pin);
 #define portOutputRegister(x)  (x)
 #define portInputRegister(x)   (x)
 
-void analogReadResolution(int bits);
+#if defined(CONFIG_PWM) || defined(CONFIG_DAC)
 void analogWriteResolution(int bits);
+#endif
 
 #include <variant.h>
 


### PR DESCRIPTION
- Remove duplicated `analogReadResolution` declaration
- Add the same #ifdef conditions used in the implementation to the `analogWriteResolution` as well.