### PR TITLE
core: arduino: analogWrite: Fix max value calculation

### DIFF
--- a/cores/arduino/zephyrCommon.cpp
+++ b/cores/arduino/zephyrCommon.cpp
@@ -316,6 +316,7 @@ int analogWriteResolution() {
 #ifdef CONFIG_PWM
 
 void analogWrite(pin_size_t pinNumber, int value) {
+	const int maxInput = BIT(_analog_write_resolution) - 1U;
 	size_t idx = pwm_pin_index(pinNumber);
 
 	if (idx >= ARRAY_SIZE(arduino_pwm)) {
@@ -327,19 +328,15 @@ void analogWrite(pin_size_t pinNumber, int value) {
 	}
 
 	_reinit_peripheral_if_needed(pinNumber, arduino_pwm[idx].dev);
-	value = map(value, 0, 1 << _analog_write_resolution, 0, arduino_pwm[idx].period);
+	value = CLAMP(value, 0, maxInput);
 
-	if (((uint32_t)value) > arduino_pwm[idx].period) {
-		value = arduino_pwm[idx].period;
-	} else if (value < 0) {
-		value = 0;
-	}
+	const uint32_t pulse = map(value, 0, maxInput, 0, arduino_pwm[idx].period);
 
 	/*
 	 * A duty ratio determines by the period value defined in dts
 	 * and the value arguments. So usually the period value sets as 255.
 	 */
-	(void)pwm_set_pulse_dt(&arduino_pwm[idx], value);
+	(void)pwm_set_pulse_dt(&arduino_pwm[idx], pulse);
 }
 
 #endif


### PR DESCRIPTION
- Fixed input max value calculation (Needs to be -1 after shift)
- Clamp calculations are performed first, eliminating cast