### PR TITLE
llext: libc: Added missing lib exports

### DIFF
--- a/cores/arduino/llext_wrappers.c
+++ b/cores/arduino/llext_wrappers.c
@@ -75,6 +75,9 @@ W3(int, strncmp, const char *, const char *, size_t)
 W2(int, strcasecmp, const char *, const char *)
 W3(char *, strncpy, char *, const char *, size_t)
 W2(char *, strcat, char *, const char *)
+W2(char *, strcpy, char *, const char *)
+W3(int, memcmp, const void *, const void *, int)
+W2(void *, memset, void *, int)
 
 /* stdlib.h - conversion */
 W2(double, strtod, const char *, char **)

--- a/loader/llext_exports.c
+++ b/loader/llext_exports.c
@@ -39,6 +39,9 @@ EXPORT_LIBC_SYM(strlen);
 EXPORT_LIBC_SYM(strnlen);
 EXPORT_LIBC_SYM(strchr);
 EXPORT_LIBC_SYM(strcat);
+EXPORT_LIBC_SYM(strcpy);
+EXPORT_LIBC_SYM(memcmp);
+EXPORT_LIBC_SYM(memset);
 
 // stdlib.h
 EXPORT_LIBC_SYM(malloc);


### PR DESCRIPTION
strcpy, memcmp and memset were missing from export, they are however exported by zephyr llext/llext_export.c.