### PR TITLE
scancode: fix new file detection to ignore submodules

### DIFF
--- a/.github/workflows/scancode.yml
+++ b/.github/workflows/scancode.yml
@@ -21,7 +21,7 @@ jobs:
         mkdir scancode-inputs
         git fetch origin $GITHUB_BASE_REF
         # copy all new files to a separate directory for scanning
-        for NEW_FILE in $(git diff --name-only --diff-filter=A origin/$GITHUB_BASE_REF..HEAD) ; do
+        for NEW_FILE in $(git diff --name-only --diff-filter=A --ignore-submodules origin/$GITHUB_BASE_REF..HEAD) ; do
           mkdir -p $(dirname "scancode-inputs/$NEW_FILE")
           cp "$NEW_FILE" "scancode-inputs/$NEW_FILE"
           echo 'NEW_FILES_FOUND=true' >> $GITHUB_ENV


### PR DESCRIPTION
They appear as regular files but can't be copied without '-r', causing an error and preventing the scan from running properly (like here: https://github.com/arduino/ArduinoCore-zephyr/actions/runs/22667558836/job/65703056192?pr=370).