### PR TITLE
unoq: enable spi peripheral interface

### DIFF
--- a/variants/arduino_uno_q_stm32u585xx/arduino_uno_q_stm32u585xx.overlay
+++ b/variants/arduino_uno_q_stm32u585xx/arduino_uno_q_stm32u585xx.overlay
@@ -190,6 +190,14 @@
 	};
 };
 
+&spi3 {
+	device0: device@0 {
+        compatible = "zephyr,spi-slave";
+        reg = <0>;
+		zephyr,deferred-init;
+	};
+};
+
 / {
 	zephyr,user {
 		digital-pin-gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>, /* D0 - PB7 */


### PR DESCRIPTION
Can be used with a class similar to

```
#ifndef SPI_PERIPHERAL_H
#define SPI_PERIPHERAL_H

#include <zephyr/kernel.h>
#include <zephyr/device.h>
#include <zephyr/init.h>
#include <zephyr/drivers/spi.h>

#ifdef CONFIG_BOARD_ARDUINO_UNO_Q

#define SPI_PERIPHERAL_NODE DT_COMPAT_GET_ANY_STATUS_OKAY(zephyr_spi_slave)

template <int SPI_MAX_MESSAGE>
class SPIPeripheralClass {
public:
    SPIPeripheralClass() {
        spi_cfg.frequency = 1000000;
        spi_cfg.operation = SPI_WORD_SET(8) | SPI_OP_MODE_SLAVE;
        rx.buf = rxmsg;
        rx.len = SPI_MAX_MESSAGE;
        rx_bufs.buffers = &rx;
        rx_bufs.count = 1;
        tx.buf = txmsg;
        tx.len = SPI_MAX_MESSAGE;
        tx_bufs.buffers = &tx;
        tx_bufs.count = 1;

    }
    int begin() {
        int ret = device_init(spi_peripheral);
        return ret;
    }

    void* populate(uint8_t* buf, size_t len) {
        return memcpy(tx.buf, buf, len);
    }

    int ready() {
        return spi_transceive(spi_peripheral, &spi_cfg, &tx_bufs, &rx_bufs);
    }
private:

    const struct device *const spi_peripheral = DEVICE_DT_GET(DT_BUS(SPI_PERIPHERAL_NODE));
    struct spi_config spi_cfg;

    uint8_t rxmsg[SPI_MAX_MESSAGE];
    struct spi_buf rx ;
    struct spi_buf_set rx_bufs;

    uint8_t txmsg[SPI_MAX_MESSAGE];
    struct spi_buf tx ;
    struct spi_buf_set tx_bufs;
};

#endif
#endif //SPI_PERIPHERAL_H
```

Sketch:

```
SPIPeripheralClass<512> spi;

void setup() {
  spi.begin();
}

int i = 0;
void loop() {
  spi.populate((uint8_t*)&i, 4);
  spi.ready();
  i++;
}
```

Linux side:

```
pip install spidev
sudo chown arduino /dev/spidev0.0
python3

import spidev
spi = spidev.SpiDev()
spi.open_path("/dev/spidev0.0")
spi.max_speed_hz = 20000000
spi.readbytes(512)
```

IMPORTANT: you must always read the full buffer size (declared in the template instantiation)