### PR TITLE
ci: enable BLE tests on Arduino UNO Q

### DIFF
--- a/extra/artifacts/zephyr_unoq.test_setup.sh
+++ b/extra/artifacts/zephyr_unoq.test_setup.sh
@@ -13,4 +13,9 @@
 # copy artifacts under the provided paths.
 
 # ArduinoBLE
-get_branch_tip libraries arduino-libraries/ArduinoBLE master
+get_branch_tip libraries arduino-libraries/ArduinoBLE master \
+	examples/Central/LedControl \
+	examples/Central/Scan \
+	examples/Peripheral/Advertising/EnhancedAdvertising \
+	examples/Peripheral/ButtonLED \
+

--- a/variants/arduino_uno_q_stm32u585xx/skip_these_examples.txt
+++ b/variants/arduino_uno_q_stm32u585xx/skip_these_examples.txt
@@ -8,5 +8,4 @@
 # Each line in this file should contain the path to an example to exclude,
 # relative to the root of the repository.
 
-libraries/ArduinoBLE
 libraries/Arduino_RPClite/extras/integration_test


### PR DESCRIPTION
Target is supported by the library so any PR should check this functionality in the CI runs.