### PR TITLE
libraries/SocketWrapper: squash unused argument warning

### DIFF
--- a/libraries/SocketWrapper/SocketHelpers.cpp
+++ b/libraries/SocketWrapper/SocketHelpers.cpp
@@ -154,9 +154,12 @@ void NetworkInterface::setMACAddress(const uint8_t *mac) {
 
 int NetworkInterface::begin(bool blocking, uint64_t additional_event_mask) {
 	dhcp();
+
 	// FIXME: additional_event_mask cannot be ORed here due to how Zephyr
 	// events are handled internally. Must be reworked to wait on a sem
 	// and register multiple event masks with event_handler instead.
+	ARG_UNUSED(additional_event_mask);
+
 	int ret = net_mgmt_event_wait_on_iface(netif, NET_EVENT_IPV4_ADDR_ADD, NULL, NULL, NULL,
 										   blocking ? K_FOREVER : K_SECONDS(1));
 	return (ret == 0) ? 1 : 0;


### PR DESCRIPTION
This argument is not used and a proper refactor is still pending, so just mark it as unused for now to avoid warnings.