### PR TITLE
zephyrCommon: fix issues with invalid pin numbers

### DIFF
--- a/cores/arduino/zephyrCommon.cpp
+++ b/cores/arduino/zephyrCommon.cpp
@@ -24,6 +24,13 @@ static const struct gpio_dt_spec arduino_pins[] = {
 	DT_FOREACH_PROP_ELEM_SEP(
 	DT_PATH(zephyr_user), digital_pin_gpios, GPIO_DT_SPEC_GET_BY_IDX, (, ))};
 
+#define RETURN_ON_INVALID_PIN(pinNumber, ...)                                                      \
+	do {                                                                                           \
+		if ((pin_size_t)(pinNumber) >= ARRAY_SIZE(arduino_pins)) {                                 \
+			return __VA_ARGS__;                                                                    \
+		}                                                                                          \
+	} while (0)
+
 namespace {
 
 #if DT_PROP_LEN(DT_PATH(zephyr_user), digital_pin_gpios) > 0
@@ -114,6 +121,8 @@ struct gpio_port_callback *find_gpio_port_callback(const struct device *dev) {
 }
 
 void setInterruptHandler(pin_size_t pinNumber, voidFuncPtr func) {
+	RETURN_ON_INVALID_PIN(pinNumber);
+
 	struct gpio_port_callback *pcb = find_gpio_port_callback(arduino_pins[pinNumber].port);
 
 	if (pcb) {
@@ -222,6 +231,8 @@ void yield(void) {
  *  A high physical level will be interpreted as value 1
  */
 void pinMode(pin_size_t pinNumber, PinMode pinMode) {
+	RETURN_ON_INVALID_PIN(pinNumber);
+
 	_reinit_peripheral_if_needed(pinNumber, NULL);
 	if (pinMode == INPUT) { // input mode
 		gpio_pin_configure_dt(&arduino_pins[pinNumber], GPIO_INPUT | GPIO_ACTIVE_HIGH);
@@ -237,10 +248,14 @@ void pinMode(pin_size_t pinNumber, PinMode pinMode) {
 }
 
 void digitalWrite(pin_size_t pinNumber, PinStatus status) {
+	RETURN_ON_INVALID_PIN(pinNumber);
+
 	gpio_pin_set_dt(&arduino_pins[pinNumber], status);
 }
 
 PinStatus digitalRead(pin_size_t pinNumber) {
+	RETURN_ON_INVALID_PIN(pinNumber, LOW);
+
 	return (gpio_pin_get_dt(&arduino_pins[pinNumber]) == 1) ? HIGH : LOW;
 }
 
@@ -258,6 +273,8 @@ void tone_timeout_cb(struct k_timer *timer) {
 }
 
 void tone(pin_size_t pinNumber, unsigned int frequency, unsigned long duration) {
+	RETURN_ON_INVALID_PIN(pinNumber);
+
 	struct k_timer *timer = &arduino_pin_timers[pinNumber];
 	const struct gpio_dt_spec *spec = &arduino_pins[pinNumber];
 	k_timeout_t timeout;
@@ -285,6 +302,8 @@ void tone(pin_size_t pinNumber, unsigned int frequency, unsigned long duration) 
 }
 
 void noTone(pin_size_t pinNumber) {
+	RETURN_ON_INVALID_PIN(pinNumber);
+
 	k_timer_stop(&arduino_pin_timers[pinNumber]);
 	gpio_pin_set_dt(&arduino_pins[pinNumber], 0);
 }
@@ -432,6 +451,8 @@ int analogRead(pin_size_t pinNumber) {
 #endif
 
 void attachInterrupt(pin_size_t pinNumber, voidFuncPtr callback, PinStatus pinStatus) {
+	RETURN_ON_INVALID_PIN(pinNumber);
+
 	struct gpio_port_callback *pcb;
 	gpio_flags_t intmode = 0;
 
@@ -467,6 +488,8 @@ void attachInterrupt(pin_size_t pinNumber, voidFuncPtr callback, PinStatus pinSt
 }
 
 void detachInterrupt(pin_size_t pinNumber) {
+	RETURN_ON_INVALID_PIN(pinNumber);
+
 	setInterruptHandler(pinNumber, nullptr);
 	disableInterrupt(pinNumber);
 }
@@ -490,6 +513,8 @@ long random(long max) {
 #endif
 
 unsigned long pulseIn(pin_size_t pinNumber, uint8_t state, unsigned long timeout) {
+	RETURN_ON_INVALID_PIN(pinNumber, LOW);
+
 	struct k_timer timer;
 	int64_t start, end, delta = 0;
 	const struct gpio_dt_spec *spec = &arduino_pins[pinNumber];
@@ -529,6 +554,8 @@ cleanup:
 }
 
 void enableInterrupt(pin_size_t pinNumber) {
+	RETURN_ON_INVALID_PIN(pinNumber);
+
 	struct gpio_port_callback *pcb = find_gpio_port_callback(arduino_pins[pinNumber].port);
 
 	if (pcb) {
@@ -537,6 +564,8 @@ void enableInterrupt(pin_size_t pinNumber) {
 }
 
 void disableInterrupt(pin_size_t pinNumber) {
+	RETURN_ON_INVALID_PIN(pinNumber);
+
 	struct gpio_port_callback *pcb = find_gpio_port_callback(arduino_pins[pinNumber].port);
 
 	if (pcb) {
@@ -558,8 +587,10 @@ void noInterrupts(void) {
 	}
 }
 
-int digitalPinToInterrupt(pin_size_t pin) {
-	struct gpio_port_callback *pcb = find_gpio_port_callback(arduino_pins[pin].port);
+int digitalPinToInterrupt(pin_size_t pinNumber) {
+	RETURN_ON_INVALID_PIN(pinNumber, -1);
 
-	return (pcb) ? pin : -1;
+	struct gpio_port_callback *pcb = find_gpio_port_callback(arduino_pins[pinNumber].port);
+
+	return (pcb) ? pinNumber : -1;
 }


### PR DESCRIPTION
Passing -1 to digital I/O functions may happen when libraries do not properly sanitize their inputs, leading to undefined behavior. 
This PR adds a check to ensure that the pin number is valid before accessing the `arduino_pins` array.