### PR TITLE
core: arduino: add ShiftIn/ShiftOut implementation 

### DIFF
--- a/cores/arduino/wiring_shift.cpp
+++ b/cores/arduino/wiring_shift.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026 KurtE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <Arduino.h>
+
+uint8_t shiftIn(pin_size_t dataPin, uint8_t clockPin, BitOrder bitOrder) {
+	uint8_t value = 0;
+	uint8_t mask;
+
+	if (bitOrder == LSBFIRST) {
+		for (mask = 0x01; mask; mask <<= 1) {
+			digitalWrite(clockPin, HIGH);
+			if (digitalRead(dataPin)) {
+				value |= mask;
+			}
+			digitalWrite(clockPin, LOW);
+		}
+	} else {
+		for (mask = 0x80; mask; mask >>= 1) {
+			digitalWrite(clockPin, HIGH);
+			if (digitalRead(dataPin)) {
+				value |= mask;
+			}
+			digitalWrite(clockPin, LOW);
+		}
+	}
+
+	return value;
+}
+
+void shiftOut(pin_size_t dataPin, uint8_t clockPin, BitOrder bitOrder, uint8_t val) {
+	uint8_t mask;
+
+	if (bitOrder == LSBFIRST) {
+		for (mask = 0x01; mask; mask <<= 1) {
+			digitalWrite(dataPin, !!(val & mask) ? HIGH : LOW);
+			digitalWrite(clockPin, HIGH);
+			digitalWrite(clockPin, LOW);
+		}
+	} else {
+		for (mask = 0x80; mask; mask >>= 1) {
+			digitalWrite(dataPin, !!(val & mask) ? HIGH : LOW);
+			digitalWrite(clockPin, HIGH);
+			digitalWrite(clockPin, LOW);
+		}
+	}
+}


### PR DESCRIPTION
resolves: #345 

Note: I simply copied in the MBED version of this.  The APIS were already contained within the header files.

Verified that the sketch within the issue built.
Modified it to verify that worked at all:
```
void setup() {
  // put your setup code here, to run once:
  pinMode(2, INPUT);
  pinMode(3, OUTPUT);
  pinMode(4, OUTPUT);
  pinMode(5, OUTPUT);
  //shiftIn(2, 3, MSBFIRST);
  //shiftOut(4, 5, LSBFIRST, 42);
  pinMode(LED_BUILTIN, OUTPUT);

}

uint8_t loop_count = 0;
void loop() {
  // put your main code here, to run repeatedly:
  loop_count++;
  digitalWrite(LED_BUILTIN, loop_count & 1);
  shiftOut(4, 5, LSBFIRST, loop_count);
  delay(1);
}

```
Built and ran on UnoQ with current sources as of this morning.
<img width="1318" height="374" alt="image" src="https://github.com/user-attachments/assets/3ee598c0-3c54-4c26-93a0-76267d2b2ba1" />

It has the same possible issue as the MBED version in that the faster the processor, the narrower the pulses are:
<img width="561" height="341" alt="image" src="https://github.com/user-attachments/assets/77229954-e2bd-43d9-9d19-a19a8cd6faa7" />
I know in the case of Teensy 4.x boards, they put in possible delays, but that could be looked at later if needed.

