### PR TITLE
zephyrSerial: avoid reinitialization of SerialUSB UART

### DIFF
--- a/cores/arduino/SerialUSB.h
+++ b/cores/arduino/SerialUSB.h
@@ -41,6 +41,10 @@ protected:
 	uint32_t baudrate;
 	static void baudChangeHandler(const struct device *dev, uint32_t rate);
 
+	void _reinit_if_needed() override {
+		/* prevent reinit: USB device is always available */
+	}
+
 private:
 	bool started = false;
 

--- a/cores/arduino/zephyrSerial.cpp
+++ b/cores/arduino/zephyrSerial.cpp
@@ -59,7 +59,7 @@ void arduino::ZephyrSerial::begin(unsigned long baud, uint16_t conf) {
 		.flow_ctrl = UART_CFG_FLOW_CTRL_NONE,
 	};
 
-	uart->ops.init(uart);
+	_reinit_if_needed();
 
 	uart_configure(uart, &config);
 	uart_irq_callback_user_data_set(uart, arduino::ZephyrSerial::IrqDispatch, this);

--- a/cores/arduino/zephyrSerial.h
+++ b/cores/arduino/zephyrSerial.h
@@ -107,6 +107,10 @@ protected:
 	const struct device *uart;
 	ZephyrSerialBuffer<CONFIG_ARDUINO_API_SERIAL_BUFFER_SIZE> tx;
 	ZephyrSerialBuffer<CONFIG_ARDUINO_API_SERIAL_BUFFER_SIZE> rx;
+
+	virtual void _reinit_if_needed() {
+		uart->ops.init(uart);
+	}
 };
 
 } // namespace arduino


### PR DESCRIPTION
Temporary workaround to prevent USB device reinit until proper pin muxing is implemented.