### PR TITLE
sync-zephyr-artifacts: try shorter hashes

### DIFF
--- a/extra/sync-zephyr-artifacts/main.go
+++ b/extra/sync-zephyr-artifacts/main.go
@@ -17,36 +17,6 @@ import (
 	cp "github.com/otiai10/copy"
 )
 
-func downloadFile(filepath string, url string) (err error) {
-
-	// Create the file
-	out, err := os.Create(filepath)
-	if err != nil {
-		return err
-	}
-	defer out.Close()
-
-	// Get the data
-	resp, err := http.Get(url)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	// Check server response
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("bad status: %s", resp.Status)
-	}
-
-	// Writer the body to file
-	_, err = io.Copy(out, resp.Body)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
 func main() {
 
 	// Create a temporary folder, download a URL based on a git tag in it
@@ -124,28 +94,47 @@ func main() {
 	}
 
 	// Compose download URL from git hash
-	hash := inputHash
-	filename := fmt.Sprintf("ArduinoCore-zephyr-%s.tar.bz2", hash)
-	url := fmt.Sprintf("http://downloads.arduino.cc/cores/zephyr/%s", filename)
-	fmt.Println("Download URL:", url)
-	// Download the zip file from the URL
-	zipFilePath := filepath.Join(tmpDir, filename)
-	err = downloadFile(zipFilePath, url)
-	if err != nil {
-		fmt.Println("Error downloading archive:", err)
-		return
-	}
-	fmt.Println("Downloaded archive to:", zipFilePath)
-	// Extract the tar.bz2 file to the temporary folder
-	// Use packer/tar and compress/bzip2 to extract the file
-	file, err := os.Open(filepath.Join(tmpDir, filename))
-	if err != nil {
-		fmt.Println("Error opening archive:", err)
-		return
-	}
-	defer file.Close()
+	var archive_stream io.Reader
 
-	err = extract.Bz2(context.Background(), file, filepath.Join(tmpDir, "extract"), nil)
+	hash := inputHash
+	for len(hash) >= 7 {
+		filename := fmt.Sprintf("ArduinoCore-zephyr-%s.tar.bz2", hash)
+		url := fmt.Sprintf("http://downloads.arduino.cc/cores/zephyr/%s", filename)
+		fmt.Println("Trying URL:", url)
+		// Download the zip file from the URL
+
+		// Get the data
+		resp, err := http.Get(url)
+		if err != nil {
+			fmt.Println("Error downloading", url, err)
+			return
+		}
+		defer resp.Body.Close()
+
+		// Check server response, try shorter hashes if not found
+		if resp.StatusCode == http.StatusNotFound {
+			resp.Body.Close()
+			hash = hash[:len(hash)-1]
+			continue
+		} else if resp.StatusCode != http.StatusOK {
+			fmt.Println("bad status:", resp.Status)
+			return
+		}
+
+		archive_stream = resp.Body
+		break
+	}
+
+	if archive_stream == nil {
+		fmt.Println("Could not find a valid archive for git hash", inputHash)
+		return
+	}
+
+	fmt.Println("Downloading and extracting...")
+
+	// extract the archive just received to tmpDir/
+	err = extract.Bz2(context.Background(), archive_stream, tmpDir, nil)
+
 	if err != nil {
 		fmt.Println("Error extracting archive:", err)
 		return
@@ -166,13 +155,13 @@ func main() {
 	})
 
 	// Copy the content of firmware folder to gitCorePath/firmware
-	err = cp.Copy(filepath.Join(tmpDir, "extract", "ArduinoCore-zephyr", "firmwares"), filepath.Join(gitCorePath, "firmwares"))
+	err = cp.Copy(filepath.Join(tmpDir, "ArduinoCore-zephyr", "firmwares"), filepath.Join(gitCorePath, "firmwares"))
 	if err != nil {
 		fmt.Println("Error copying firmware folder:", err)
 		return
 	}
 	// Copy the content of variants folder to gitCorePath/variants
-	err = cp.Copy(filepath.Join(tmpDir, "extract", "ArduinoCore-zephyr", "variants"), filepath.Join(gitCorePath, "variants"))
+	err = cp.Copy(filepath.Join(tmpDir, "ArduinoCore-zephyr", "variants"), filepath.Join(gitCorePath, "variants"))
 	if err != nil {
 		fmt.Println("Error copying variants folder:", err)
 		return


### PR DESCRIPTION
The git archive has increased and files have been saved with 8 chars. Go with the robust option and try shorter hashes if the one returned by `git describe` is longer than the one used at the time of file generation.