### PR TITLE
llext: add strdup to exports

### DIFF
--- a/cores/arduino/llext_wrappers.c
+++ b/cores/arduino/llext_wrappers.c
@@ -80,6 +80,7 @@ W3(int, memcmp, const void *, const void *, unsigned int)
 W3(void *, memset, void *, int, unsigned int)
 W2(char *, strtok, char *, const char *)
 W3(void *, memchr, const void *, int, size_t)
+W1(char *, strdup, const char *)
 
 /* stdlib.h - conversion */
 W2(double, strtod, const char *, char **)

--- a/loader/llext_exports.c
+++ b/loader/llext_exports.c
@@ -45,6 +45,7 @@ EXPORT_LIBC_SYM(memcmp);
 EXPORT_LIBC_SYM(memset);
 EXPORT_LIBC_SYM(strtok);
 EXPORT_LIBC_SYM(memchr);
+EXPORT_LIBC_SYM(strdup);
 
 // stdlib.h
 EXPORT_LIBC_SYM(malloc);


### PR DESCRIPTION
needed to build 256dpi/arduino-mqtt examples