### PR TITLE
PWM: Fix Nano 33 PWM period configuration in variant overlays

### DIFF
--- a/variants/arduino_nano_33_ble_nrf52840_sense/arduino_nano_33_ble_nrf52840_sense.overlay
+++ b/variants/arduino_nano_33_ble_nrf52840_sense/arduino_nano_33_ble_nrf52840_sense.overlay
@@ -118,13 +118,13 @@
 
 		builtin-led-gpios = <&arduino_nano_header 13 0>;
 
-		pwms =	<&pwm1 1 255 PWM_POLARITY_NORMAL>,
-			<&pwm1 2 255 PWM_POLARITY_NORMAL>,
-			<&pwm1 3 255 PWM_POLARITY_NORMAL>,
-			<&pwm2 0 255 PWM_POLARITY_NORMAL>,
-			<&pwm2 1 255 PWM_POLARITY_NORMAL>,
-			<&pwm2 2 255 PWM_POLARITY_NORMAL>,
-			<&pwm2 3 255 PWM_POLARITY_NORMAL>;
+		pwms =	<&pwm1 1 PWM_HZ(500) PWM_POLARITY_NORMAL>,
+			<&pwm1 2 PWM_HZ(500) PWM_POLARITY_NORMAL>,
+			<&pwm1 3 PWM_HZ(500) PWM_POLARITY_NORMAL>,
+			<&pwm2 0 PWM_HZ(500) PWM_POLARITY_NORMAL>,
+			<&pwm2 1 PWM_HZ(500) PWM_POLARITY_NORMAL>,
+			<&pwm2 2 PWM_HZ(500) PWM_POLARITY_NORMAL>,
+			<&pwm2 3 PWM_HZ(500) PWM_POLARITY_NORMAL>;
 
 		io-channels =	<&adc 2>,
 				<&adc 3>,


### PR DESCRIPTION
This PR updates the Nano 33 BLE variant overlays to use a real PWM period definition instead of a fixed scalar value.

The PWM entries in both Nano overlays were changed from 255 to PWM_HZ(500), aligning them with the configuration style used by other boards and restoring correct analogWrite behavior on Nordic targets.