### PR TITLE
core: add `errno` and other TLS variables support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ cxxflags.txt
 includes.txt
 syms-dynamic.ld
 syms-static.ld
+tls-syms.S

--- a/cores/arduino/llext_wrappers.c
+++ b/cores/arduino/llext_wrappers.c
@@ -62,6 +62,7 @@
 		__real_##name(a);                                                                          \
 	}
 
+#ifdef CONFIG_ARM
 /*
  * Naked trampoline for compiler ABI helpers (__aeabi_*).
  *
@@ -79,6 +80,7 @@
 				"movt r12, #:upper16:__real_" #name "\n\t"                                         \
 				"bx   r12");                                                                       \
 	}
+#endif
 
 /* string.h */
 W3(void *, memcpy, void *, const void *, size_t)
@@ -162,7 +164,10 @@ W1(float, sinf, float)
 W1(float, sqrtf, float)
 W1(float, tanf, float)
 
-/* compiler ABI helpers: need to preserve all RTABI argument registers */
+#ifdef CONFIG_ARM
+/* ARM compiler ABI helpers: need to preserve all RTABI argument registers */
+/* thread pointer access */
+VN(__aeabi_read_tp)
 /* double arithmetic */
 VN(__aeabi_dadd)
 VN(__aeabi_dsub)
@@ -198,6 +203,7 @@ VN(__aeabi_idivmod)
 VN(__aeabi_uidivmod)
 VN(__aeabi_ldivmod)
 VN(__aeabi_uldivmod)
+#endif
 
 /* stdio.h */
 W1(int, puts, const char *)

--- a/extra/build.sh
+++ b/extra/build.sh
@@ -102,6 +102,7 @@ cp ${BUILD_DIR}/zephyr/.config firmwares/zephyr-$variant.config
 
 # Generate the provides.ld file for linked builds
 echo "Generating exported symbol scripts"
+extra/gen_provides.py "${BUILD_DIR}/zephyr/zephyr.elf" -T > ${VARIANT_DIR}/tls-syms.S
 extra/gen_provides.py "${BUILD_DIR}/zephyr/zephyr.elf" -L > ${VARIANT_DIR}/syms-dynamic.ld
 extra/gen_provides.py "${BUILD_DIR}/zephyr/zephyr.elf" -LF \
 	"+kheap_llext_heap" \

--- a/extra/gen_provides.py
+++ b/extra/gen_provides.py
@@ -122,6 +122,9 @@ def main():
     argparser.add_argument('-F', '--funcs',
             action='store_true',
             help='Extract all public functions')
+    argparser.add_argument('-T', '--tls-defs',
+            action='store_true',
+            help='Extract TLS symbol offsets to a .S file')
     argparser.add_argument('file',
             help='ELF file to parse')
     argparser.add_argument('syms', nargs='*',
@@ -129,10 +132,19 @@ def main():
 
     args = argparser.parse_intermixed_args()
 
+    wants_provides = bool(args.syms or args.funcs or args.llext)
+    if wants_provides and args.tls_defs:
+        sys.stderr.write("Cannot generate TLS defs when also generating PROVIDEs.\n")
+        sys.exit(1)
+    elif not wants_provides and not args.tls_defs:
+        sys.stderr.write("Nothing specified for export.\n")
+        sys.exit(1)
+
     exact_syms = set()
     regex_syms = set()
     deref_syms = set()
     sized_syms = set()
+    tls_syms = set() # tuple of (name, value, size)
     rename_map = {}
     for sym in args.syms:
         sym_class = None
@@ -184,6 +196,11 @@ def main():
         fail = False
 
         for name, sym in all_syms.items():
+            if sym['st_info']['type'] == 'STT_TLS':
+                # Collect TLS symbol information, ignore for PROVIDEs
+                tls_syms.add((name, sym['st_value'], sym['st_size']))
+                continue
+
             value = None
             comment = []
             if name in exact_syms or any(re.match(r, name) for r in regex_syms):
@@ -232,20 +249,46 @@ def main():
  */
 """)
 
-        if not out_syms:
-            print("/* No symbols found matching the criteria */")
-            sys.stderr.write("warning: no symbols found matching the criteria.\n")
-        else:
-            sym_comment = nul_comment = ""
-            for name, (value, comments) in sorted(out_syms.items(), key=lambda x: x[0]):
-                if args.verbose:
-                    comment = ', '.join(sorted(comments))
-                    sym_comment = f"/* {comment} */"
-                    nul_comment = f" ({comment})"
-                if value:
-                    print(f"PROVIDE({name} = {value:#010x});{sym_comment}")
-                else:
-                    print(f"/* NULL {name}{nul_comment} */")
+        if wants_provides:
+            if not out_syms:
+                print("/* No symbols found matching the criteria */")
+                sys.stderr.write("warning: no symbols found matching the criteria.\n")
+            else:
+                sym_comment = nul_comment = ""
+                for name, (value, comments) in sorted(out_syms.items(), key=lambda x: x[0]):
+                    if args.verbose:
+                        comment = ', '.join(sorted(comments))
+                        sym_comment = f"/* {comment} */"
+                        nul_comment = f" ({comment})"
+                    if value:
+                        print(f"PROVIDE({name} = {value:#010x});{sym_comment}")
+                    else:
+                        print(f"/* NULL {name}{nul_comment} */")
+
+        if args.tls_defs:
+            # ARM and AArch64 use '@' as a line-comment character in GAS, so the
+            # assembler requires '%' as the type prefix there.  All other targets use '@'.
+            prefix = '%' if elf['e_machine'] in ('EM_ARM', 'EM_AARCH64') else '@'
+
+            # The TLS Variant 1 layout (used by ARM/AArch64) places a Thread
+            # Control Block (TCB) before the TLS data.  The thread pointer
+            # returned by __aeabi_read_tp() points to the TCB, so the actual
+            # runtime address of a TLS variable must be offset by that size.
+            #
+            # TCB is 2 pointers: 8 bytes on 32-bit, 16 bytes on 64-bit.
+            # See zephyr/arch/arm/core/tls.c: arch_tls_stack_setup().
+            tcb_size = (elf.elfclass // 8) * 2
+            print(f"/* Offsets include {tcb_size} bytes for TCB data */")
+
+            # Sort by offset first, then size
+            for name, offset, size in sorted(tls_syms, key=lambda x: (x[1], x[2])):
+                offset += tcb_size
+                print(
+                    f"\n/* TLS offset {offset:#x}: {name} ({size} bytes) */\n"
+                    f".global {name}\n"
+                    f".type {name}, {prefix}tls_object\n"
+                    f".set {name}, {offset}"
+                )
 
 #-------------------------------------------------------------------------------
 if __name__ == '__main__':

--- a/extra/gen_provides.py
+++ b/extra/gen_provides.py
@@ -220,10 +220,6 @@ def main():
             if name in sized_syms:
                 out_syms[name + "_size"] = (sym['st_size'], [f"size of {name}"])
 
-        if not out_syms:
-            sys.stderr.write("No symbols found matching the criteria.\n")
-            fail = True
-
         if fail:
             sys.exit(1)
 
@@ -235,16 +231,21 @@ def main():
  * SHA256: {elf_sha}
  */
 """)
-        sym_comment = nul_comment = ""
-        for name, (value, comments) in sorted(out_syms.items(), key=lambda x: x[0]):
-            if args.verbose:
-                comment = ', '.join(sorted(comments))
-                sym_comment = f"/* {comment} */"
-                nul_comment = f" ({comment})"
-            if value:
-                print(f"PROVIDE({name} = {value:#010x});{sym_comment}")
-            else:
-                print(f"/* NULL {name}{nul_comment} */")
+
+        if not out_syms:
+            print("/* No symbols found matching the criteria */")
+            sys.stderr.write("warning: no symbols found matching the criteria.\n")
+        else:
+            sym_comment = nul_comment = ""
+            for name, (value, comments) in sorted(out_syms.items(), key=lambda x: x[0]):
+                if args.verbose:
+                    comment = ', '.join(sorted(comments))
+                    sym_comment = f"/* {comment} */"
+                    nul_comment = f" ({comment})"
+                if value:
+                    print(f"PROVIDE({name} = {value:#010x});{sym_comment}")
+                else:
+                    print(f"/* NULL {name}{nul_comment} */")
 
 #-------------------------------------------------------------------------------
 if __name__ == '__main__':

--- a/loader/llext_exports.c
+++ b/loader/llext_exports.c
@@ -325,7 +325,10 @@ EXPORT_SYMBOL(ring_buf_area_finish);
 
 EXPORT_SYMBOL(sys_clock_cycle_get_32);
 
-/* compiler ABI helpers: exported as __real_##name for VN() trampolines in llext_wrappers.c */
+#ifdef CONFIG_ARM
+/* ARM compiler ABI helpers: exported as __real_##name for VN() trampolines in llext_wrappers.c */
+/* thread pointer access */
+EXPORT_AEABI_SYM(__aeabi_read_tp);
 /* double arithmetic */
 EXPORT_AEABI_SYM(__aeabi_dadd);
 EXPORT_AEABI_SYM(__aeabi_dsub);
@@ -361,6 +364,7 @@ EXPORT_AEABI_SYM(__aeabi_idivmod);
 EXPORT_AEABI_SYM(__aeabi_uidivmod);
 EXPORT_AEABI_SYM(__aeabi_ldivmod);
 EXPORT_AEABI_SYM(__aeabi_uldivmod);
+#endif
 
 #if defined(CONFIG_CPP)
 FORCE_EXPORT_SYM(__cxa_pure_virtual);


### PR DESCRIPTION
This PR adds support for Thread Local Storage (TLS) variables to the Zephyr core. 

This is achieved by extracting TLS variable offsets from the built loader and creating a TLS wrapper assembly file that defines the same symbols and offsets. This is then picked up by the CLI, compiled and linked in the sketch build so that the exported symbols are properly identified.

To test this, add the following snippet to a sketch:
```
        errno = 0;
        strtol("9999999999999", NULL, 10);
        Serial.println(errno);
```
(the result should be `-ERANGE` or `-34`).
Note: to test this it requires `R_ARM_TLS_LE32` support added in the Zephyr repo as well.  