### PR TITLE
libraries-support: add symbol export

### DIFF
--- a/cores/arduino/llext_wrappers.c
+++ b/cores/arduino/llext_wrappers.c
@@ -79,6 +79,7 @@ W2(char *, strcpy, char *, const char *)
 W3(int, memcmp, const void *, const void *, unsigned int)
 W3(void *, memset, void *, int, unsigned int)
 W2(char *, strtok, char *, const char *)
+W3(void *, memchr, const void *, int, size_t)
 
 /* stdlib.h - conversion */
 W2(double, strtod, const char *, char **)

--- a/loader/llext_exports.c
+++ b/loader/llext_exports.c
@@ -44,6 +44,7 @@ EXPORT_LIBC_SYM(strcpy);
 EXPORT_LIBC_SYM(memcmp);
 EXPORT_LIBC_SYM(memset);
 EXPORT_LIBC_SYM(strtok);
+EXPORT_LIBC_SYM(memchr);
 
 // stdlib.h
 EXPORT_LIBC_SYM(malloc);


### PR DESCRIPTION
This PR adds symbol export needed by Arduino_Opta_Blueprint library to be compiled using Arduino core zephyr