### PR TITLE
giga r1: update memory configuration for Arduino_Video support

### DIFF
--- a/variants/arduino_giga_r1_stm32h747xx_m7/arduino_giga_r1_stm32h747xx_m7.overlay
+++ b/variants/arduino_giga_r1_stm32h747xx_m7/arduino_giga_r1_stm32h747xx_m7.overlay
@@ -611,6 +611,11 @@
 
 /delete-node/ &sram2;
 
+&sdram1 {
+	/* Frame buffer memory cache will cause screen flickering. */
+	zephyr,memory-attr = <( DT_MEM_ARM(ATTR_MPU_RAM_NOCACHE) )>;
+};
+
 /* Include common flash filesystem configuration */
 qspi_flash: &n25q128a1 {};
 #include "../common/arduino_flash_fs.dtsi"


### PR DESCRIPTION
This PR updates the Arduino Giga R1 memory and LLEXT configuration to enable support for the [Arduino_Video](https://github.com/arduino-libraries/Arduino_Video) library (WIP) and handle the LVGL stack requirements.

I have replicated the logic implemented for the [Portenta H7](https://github.com/arduino/ArduinoCore-zephyr/pull/356) by @iabdalkader.

**Changes**:
- Device Tree: Expanded `sram1` to 256KB and deleted the `sram2` node.
- LLEXT Config: Moved `LLEXT_HEAP_REGION` to SRAM1 and increased `LLEXT_HEAP_SIZE` to 256.
- Flash & Build: Resized `user_sketch` partition and added `ARDUINO_LV_CONF_PATH` compiler flags.