### PR TITLE
scancode: fix issues with hidden files, update action version

### DIFF
--- a/.github/workflows/scancode.yml
+++ b/.github/workflows/scancode.yml
@@ -22,14 +22,15 @@ jobs:
         git fetch origin $GITHUB_BASE_REF
         # copy all new files to a separate directory for scanning
         for NEW_FILE in $(git diff --name-only --diff-filter=A --ignore-submodules origin/$GITHUB_BASE_REF..HEAD) ; do
-          mkdir -p $(dirname "scancode-inputs/$NEW_FILE")
-          cp "$NEW_FILE" "scancode-inputs/$NEW_FILE"
+          TARGET_FILE=${NEW_FILE#.} # remove leading dot if present
+          mkdir -p $(dirname "scancode-inputs/$TARGET_FILE")
+          cp "$NEW_FILE" "scancode-inputs/$TARGET_FILE"
           echo 'NEW_FILES_FOUND=true' >> $GITHUB_ENV
         done
 
     - name: Scan the code
       id: scancode
-      uses: aboutcode-org/scancode-action@beta
+      uses: aboutcode-org/scancode-action@v0.1
       if: env.NEW_FILES_FOUND == 'true'
       with:
         check-compliance: true
@@ -39,7 +40,7 @@ jobs:
       uses: actions/download-artifact@v8
       if: env.NEW_FILES_FOUND == 'true'
       with:
-        name: scancode-outputs
+        name: scancode-outputs-scancode-action
 
     - name: Process the report
       if: env.NEW_FILES_FOUND == 'true'


### PR DESCRIPTION
The action does not properly handle hidden files (those starting with a dot). 
The fix removes the leading dot from the file path when copying it to the `scancode-inputs` directory.

The action is also updated from 'beta' to 'v0.1' to take advantage of the latest features and fixes.