### PR TITLE
ci: fixes to tooling build

### DIFF
--- a/.github/workflows/package_core.yml
+++ b/.github/workflows/package_core.yml
@@ -5,24 +5,9 @@
 
 name: Package, test and upload core
 
-# Trigger on all pushes and PRs, except for changes only affecting the 'tools/'
-# directory or tagged with "tool/**".
-
 on:
   push:
-    branches:
-      - '**'
-    tags-ignore:
-      - 'tool/**'
-    paths:
-      - '**'
-      - '!extra/package_tool.sh'
-      - '!tools/**'
   pull_request:
-    paths:
-      - '**'
-      - '!extra/package_tool.sh'
-      - '!tools/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.actor }}

--- a/.github/workflows/package_core.yml
+++ b/.github/workflows/package_core.yml
@@ -90,7 +90,7 @@ jobs:
         # needs the above env vars
         run: |
           echo "## Building \`$CORE_VER\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "CORE_TAG=$(git describe --tags --exact-match 2>/dev/null || echo $CORE_HASH)" >> "$GITHUB_ENV"
+          echo "CORE_TAG=$(git describe --tags --exact-match --exclude '*/*' 2>/dev/null || echo $CORE_HASH)" >> "$GITHUB_ENV"
           echo "ALL_BOARD_FQBNS=$(jq -c 'map((. + {link_mode: "static"}), (. + {link_mode: "dynamic"}))' <<< ${ALL_BOARD_DATA})" >> "$GITHUB_ENV"
           echo "ARTIFACTS=$(jq -c '["zephyr"] + (map(.artifact) | unique)' <<< ${ALL_BOARD_DATA})" >> "$GITHUB_ENV"
           echo "SUB_ARCHES=$(jq -c 'map(.subarch) | unique' <<< ${ALL_BOARD_DATA})" >> "$GITHUB_ENV"

--- a/.github/workflows/package_tool.yml
+++ b/.github/workflows/package_tool.yml
@@ -27,6 +27,12 @@ concurrency:
 
 jobs:
 
+  # Set up the build matrix based on the event type. For tag pushes, the matrix
+  # will contain only the tool and version specified by the tag. For pull
+  # requests, the matrix will include all tools with the version set to the
+  # commit SHA. Also determine if this is a release build on the main
+  # repository, and if so, set the tool artifact name for later use.
+
   setup:
     name: Set up build matrix
     runs-on: ubuntu-latest
@@ -63,6 +69,9 @@ jobs:
           fi
           echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
 
+  # Build and package the tools in parallel according to the matrix, uploading
+  # the resulting packages and metadata as artifacts for later use.
+
   build-tool:
     name: Build ${{ matrix.tool }} ${{ matrix.version }}
     needs: setup
@@ -81,10 +90,10 @@ jobs:
           go-version: stable
           cache: false
 
-      - name: Build and package ${{ matrix.tool }}
+      - name: Build and package tool
         run: extra/package_tool.sh tools/${{ matrix.tool }} ${{ matrix.version }}
 
-      - name: Upload ${{ matrix.tool }} ${{ matrix.version }}
+      - name: Upload tool artifact
         uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.tool }}-${{ matrix.version }}
@@ -93,23 +102,13 @@ jobs:
             distrib/*.zip
           retention-days: 7
 
-      - name: Upload JSON ${{ matrix.tool }} ${{ matrix.version }}
+      - name: Upload JSON artifact
         uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.tool }}-${{ matrix.version }}.json
           path: distrib/*.json
           archive: false
           retention-days: 7
-          if-no-files-found: ignore
-
-  verify-tool:
-    runs-on: ubuntu-latest
-    if: always()
-    needs: build-tool
-    steps:
-      - name: Check build result
-        run: |
-          [ "${{ needs.build-tool.result }}" == "success" ]
 
   # Upload the built tool packages to the S3 bucket for public distribution.
 
@@ -137,10 +136,24 @@ jobs:
           role-to-assume: ${{ secrets.IAM_ROLE }}
           aws-region: ${{ secrets.AWS_REGION }}
 
-      - name: Upload tools to S3
+      - name: Upload tool files to S3
         run: |
           for f in *.tar.gz *.zip ; do
             [ -f "$f" ] || continue
             aws s3 cp "$f" s3://${{ secrets.S3_TOOLS_BUCKET }}/
           done
 
+  # The final verification step always runs to properly get the overall job status.
+
+  verify-tool:
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+     - build-tool
+     - publish-tool
+    steps:
+      - name: Check build result
+        run: |
+          # A failure here means either the build or publish step failed when it was expected to run.
+          [ ${{ needs.build-tool.result }} == "success" ] && \
+            ( [ ${{ needs.publish-tool.result }} == "success" ] || [ ${{ needs.publish-tool.result }} == "skipped" ] )

--- a/.github/workflows/package_tool.yml
+++ b/.github/workflows/package_tool.yml
@@ -6,8 +6,8 @@
 name: Package and upload tool
 
 # Trigger on any pull request that modifies files in the tools/ directory or
-# the packaging script, or on any tag that starts with tool/ and has the
-# format tool/<tool>/<version>, e.g. tool/gen-rodata-ld/0.1.0.
+# the packaging script, or on any tag that starts with tools/ and has the
+# format tools/<tool>/<version>, e.g. tools/gen-rodata-ld/0.1.0.
 #
 # For tag pushes, only build the specific tool and version indicated by the
 # tag, and only publish if the repository is the official Arduino one.
@@ -15,7 +15,7 @@ name: Package and upload tool
 on:
   push:
     tags:
-      - 'tool/**'
+      - 'tools/**'
   pull_request:
     paths:
       - 'tools/**'
@@ -44,9 +44,9 @@ jobs:
       - name: Set build matrix
         id: set-matrix
         run: |
-          if [[ "$GITHUB_REF" == refs/tags/tool/* ]]; then
+          if [[ "$GITHUB_REF" == refs/tags/tools/* ]]; then
             # single tool, release build on main repo
-            TAG="${GITHUB_REF#refs/tags/tool/}"
+            TAG="${GITHUB_REF#refs/tags/tools/}"
             TOOL="${TAG%%/*}"
             VERSION="${TAG#*/}"
             MATRIX=$(jq -cn --arg tool "$TOOL" --arg version "$VERSION" \

--- a/.github/workflows/package_tool.yml
+++ b/.github/workflows/package_tool.yml
@@ -5,22 +5,17 @@
 
 name: Package and upload tool
 
-# Trigger on any push or pull request that modifies files in the tools/
-# directory or the packaging script, or on any tag that starts with tool/.
+# Trigger on any pull request that modifies files in the tools/ directory or
+# the packaging script, or on any tag that starts with tool/ and has the
+# format tool/<tool>/<version>, e.g. tool/gen-rodata-ld/0.1.0.
 #
 # For tag pushes, only build the specific tool and version indicated by the
-# tag, and only publish if the repository is the main one
-# (arduino/ArduinoCore-zephyr).
+# tag, and only publish if the repository is the official Arduino one.
 
 on:
   push:
-    branches:
-      - '**'
     tags:
       - 'tool/**'
-    paths:
-      - 'tools/**'
-      - 'extra/package_tool.sh'
   pull_request:
     paths:
       - 'tools/**'

--- a/extra/get_core_version.sh
+++ b/extra/get_core_version.sh
@@ -33,9 +33,9 @@
 # environments the correct commit is used, even in pull requests where HEAD
 # might be a temporary detached commit.
 
-VERSION=$(git describe --tags --exact-match 2>/dev/null)
+VERSION=$(git describe --tags --exact-match --exclude '*/*' 2>/dev/null)
 if [ -z "$VERSION" ]; then
-	STEM=$(git describe --tags 2>/dev/null |
+	STEM=$(git describe --tags --exclude '*/*' 2>/dev/null |
 	       sed 's/\.\([[:digit:]]\+\)\(-.*\)*-[[:digit:]]\+-g.*/ \1 \2/' |
 	       awk '{ if (NF==2) { print $1 "." ($2+1) "-0.dev" } else { print $1 "." $2 $3 "-0.dev" }}')
 	if [ -z "$STEM" ]; then
@@ -44,8 +44,7 @@ if [ -z "$VERSION" ]; then
 	fi
 
 	# If HEAD_REF is not set, we're not in CI but in a local clone. Use the
-	# default branch (HEAD) and include --dirty to test for uncommitted
-	# changes.
-	VERSION="${STEM}+$(git describe --always ${HEAD_REF:---dirty HEAD})"
+	# implicit HEAD and include --dirty to test for uncommitted changes.
+	VERSION="${STEM}+$(git describe --always ${HEAD_REF:---dirty})"
 fi
 echo $VERSION


### PR DESCRIPTION
Fixes required by the new tooling CI workflows:

- removed filters that optimize CI runs, as they were missing some branch pushes. There is no way to describe the exact set of conditions that we need in the workflow filter syntax, so just run the core CI always.
- ignore tags with slashes when looking for the (core) version
- switch the tag names to `tools/<tool>/<version>` so tab completion works :innocent: 
- include the AWS publishing step in the `verify-tool` job