### PR TITLE
artifacts: use ci-generated tool binaries

### DIFF
--- a/extra/artifacts/_common.json
+++ b/extra/artifacts/_common.json
@@ -30,12 +30,12 @@
     {
       "packager": "arduino",
       "name": "zephyr-sketch-tool",
-      "version": "0.2.0"
+      "version": "0.2.1"
     },
     {
       "packager": "arduino",
       "name": "sync-zephyr-artifacts",
-      "version": "0.1.0"
+      "version": "0.1.1"
     },
     {
       "packager": "arduino",
@@ -55,7 +55,7 @@
     {
       "packager": "arduino",
       "name": "gen-rodata-ld",
-      "version": "0.1.0"
+      "version": "0.1.1"
     }
   ]
 }


### PR DESCRIPTION
Switch to using the tool binaries generated by CI instead of the ones generated manually. No functional change in the tool sources.