### PR TITLE
fix: analogWrite() silently fails when PWM pin lookup fails on Uno Q

### DIFF
--- a/cores/arduino/zephyrCommon.cpp
+++ b/cores/arduino/zephyrCommon.cpp
@@ -339,10 +339,14 @@ void analogWrite(pin_size_t pinNumber, int value) {
 	size_t idx = pwm_pin_index(pinNumber);
 
 	if (idx >= ARRAY_SIZE(arduino_pwm)) {
+		pinMode(pinNumber, OUTPUT);
+		digitalWrite(pinNumber, value > 127 ? HIGH : LOW);
 		return;
 	}
 
 	if (!pwm_is_ready_dt(&arduino_pwm[idx])) {
+		pinMode(pinNumber, OUTPUT);
+		digitalWrite(pinNumber, value > 127 ? HIGH : LOW);
 		return;
 	}
 


### PR DESCRIPTION
## Problem

On Arduino Uno Q, calling analogWrite() on any pin silently returns  without doing anything in two cases:

1. When pwm_pin_index() cannot find the pin in the arduino_pwm_pins[]  lookup table (idx >= ARRAY_SIZE(arduino_pwm))
2. When pwm_is_ready_dt() returns false for the PWM device

This causes analogWrite() to appear completely broken to users - no  output, no error, no warning. The function just silently does nothing.

## Root Cause

The pwm-pin-gpios mapping in the Uno Q device tree overlay is missing  some pins (D0, D1, D4 are absent or commented out). This means  pwm_pin_index() returns (size_t)-1 for those pins, which is always 
>= ARRAY_SIZE(arduino_pwm), causing an immediate silent return.

## Fix

Added a digitalWrite() fallback in both early-return paths:
- If PWM lookup fails → fall back to digitalWrite HIGH/LOW
- If PWM device not ready → fall back to digitalWrite HIGH/LOW

This ensures analogWrite() always produces some output even when  hardware PWM is unavailable, which is consistent with how other  Arduino cores handle non-PWM pins.

## Testing

Tested on Arduino Uno Q with:
- Motor driver (SmartElex L298N integrated board)
- Confirmed analogWrite() was completely silent before fix
- Confirmed digitalWrite() fallback works correctly after fix
- Pins tested: 3, 4, 5, 6, 7, 8, 9, 10

## Impact

- No breaking changes
- Existing PWM functionality unchanged
- Non-PWM pins now behave like standard Arduino (HIGH if value > 127)
- Fixes user confusion when analogWrite() silently does nothing