### PR TITLE
ci: add JSON upload to GitHub Pages workflow

### DIFF
--- a/.github/workflows/upload_json.yml
+++ b/.github/workflows/upload_json.yml
@@ -1,0 +1,73 @@
+# Copyright (c) Arduino s.r.l. and/or its affiliated companies
+# SPDX-License-Identifier: Apache-2.0
+
+# CI workflow to upload the zephyr_ci package index to GitHub Pages.
+
+name: Deploy CI JSON to GitHub Pages
+
+on:
+  workflow_run:
+    workflows: ["Package, test and upload core"]
+    types:
+      - completed
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  submit-json-to-gh-pages:
+    name: Update git JSON on Github Pages
+    runs-on: ubuntu-latest
+    if: ${{ github.repository == 'arduino/ArduinoCore-zephyr'
+            && github.event.workflow_run.event == 'push'
+            && github.event.workflow_run.head_branch == 'main'
+            && github.event.workflow_run.conclusion == 'success' }}
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}/package_zephyr_ci_index.json
+    steps:
+      - name: Download artifact
+        id: download-artifact
+        uses: dawidd6/action-download-artifact@v20
+        with:
+          workflow: package-core.yml
+          run_id: ${{ github.event.workflow_run.id }}
+          name: ArduinoCore-zephyr-.*-jsons
+          name_is_regexp: true
+
+      - name: Setup private SSH key
+        uses: webfactory/ssh-agent@v0.10.0
+        with:
+          ssh-private-key: ${{ secrets.PACKAGE_INDEX_DEPLOY_KEY }}
+
+      - name: Create zephyr_ci package index
+        run: |
+          git clone ${{ secrets.PACKAGE_INDEX_REPO }} package_index
+          mkdir -p package_index/zephyr_ci/arduino/platforms pages
+          cd package_index
+          cp ../ArduinoCore-*/*.json zephyr_ci/arduino/platforms/
+          (cd zephyr_staging && for dir in */tools ; do mkdir -p ../zephyr_ci/$dir && cp $dir/*.json ../zephyr_ci/$dir/ ; done)
+          python3 -m venv venv
+          . venv/bin/activate
+          pip install -r scripts/requirements.txt
+          scripts/meld.py prod.json prod/
+          scripts/meld.py --ref-index prod.json ../pages/package_zephyr_ci_index.json zephyr_ci/
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v6
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: 'pages/'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
Add a new GitHub Actions workflow to generate a full package index file from the CI-generated JSON snippet and upload it to GitHub Pages after a successful run of the "Package, test and upload core" workflow on the main branch.

Once this is merged, the Additional URL for the CI JSON will be:
```
https://arduino.github.io/ArduinoCore-zephyr/package_zephyr_ci_index.json
```

> [!CAUTION]
> This is **highly experimental**, so use at your own risk!

---

For example, [this CI run](https://github.com/pillo79/ArduinoCore-zephyr/actions/runs/24461247216/job/71475778621) generated [this JSON](https://pillo79.github.io/ArduinoCore-zephyr/package_zephyr_ci_index.json) which can be used as follows:
```
pillo79@host:~$ arduino-cli core list --all | grep zephyr
arduino:zephyr                     0.54.1           Arduino UNO Q Board
arduino:zephyr_contrib             0.54.1           Zephyr Community Boards (BETA)
arduino:zephyr_main                0.54.1           Arduino Zephyr Boards (BETA)
pillo79@host:~$ arduino-cli core list --all --additional-urls https://<my-fork>/package_zephyr_ci_index.json | grep zephyr
arduino:zephyr                     0.54.2-0.dev+1ec82e73 Arduino UNO Q Board
arduino:zephyr_contrib             0.54.2-0.dev+1ec82e73 Zephyr Community Boards (BETA)
arduino:zephyr_main                0.54.2-0.dev+1ec82e73 Arduino Zephyr Boards (BETA)
```