### PR TITLE
boards: adding se05x enable to digital-pin-gpios

### DIFF
--- a/variants/arduino_nicla_vision_stm32h747xx_m7/arduino_nicla_vision_stm32h747xx_m7.overlay
+++ b/variants/arduino_nicla_vision_stm32h747xx_m7/arduino_nicla_vision_stm32h747xx_m7.overlay
@@ -205,7 +205,8 @@
                             <&gpiog 1 GPIO_ACTIVE_HIGH>,    /* D3 PG_1 */
                             <&gpioe 3 GPIO_ACTIVE_HIGH>,    /* Red LED PE_3 */
                             <&gpioc 13 GPIO_ACTIVE_HIGH>,   /* Green LED PC_13 */
-                            <&gpiof 4 GPIO_ACTIVE_HIGH>;    /* Blue LED PF_4 */
+                            <&gpiof 4 GPIO_ACTIVE_HIGH>,    /* Blue LED PF_4 */
+							<&gpiog 0 GPIO_ACTIVE_HIGH>;	/* SE05X_EN */
 
         adc-pin-gpios = <&gpioc 4 GPIO_ACTIVE_HIGH>,  /* A0 PC_4 */
                         <&gpiof 13 GPIO_ACTIVE_HIGH>, /* A1 PF_13 */

--- a/variants/arduino_nicla_vision_stm32h747xx_m7/variant.h
+++ b/variants/arduino_nicla_vision_stm32h747xx_m7/variant.h
@@ -23,3 +23,5 @@
 
 #define SDA     0
 #define SCL     0
+
+#define SE05X_ENABLE_GPIO (7u)

--- a/variants/arduino_portenta_c33_r7fa6m5bh3cfc/arduino_portenta_c33_r7fa6m5bh3cfc.overlay
+++ b/variants/arduino_portenta_c33_r7fa6m5bh3cfc/arduino_portenta_c33_r7fa6m5bh3cfc.overlay
@@ -280,8 +280,9 @@
   					<&ioport2 6 GPIO_ACTIVE_HIGH>, /*   D88    |   SDHI D2   */
   					<&ioport2 5 GPIO_ACTIVE_HIGH>, /*   D89    |   SDHI D3   */
   					<&ioport4 15 GPIO_ACTIVE_HIGH>, /*   D90    |   SDHI CD   */
-  					<&ioport4 14 GPIO_ACTIVE_HIGH>; /*   D91    |   SDHI WP   */
+  					<&ioport4 14 GPIO_ACTIVE_HIGH>, /*   D91    |   SDHI WP   */
 
+					<&ioport0 10 GPIO_ACTIVE_HIGH>; /*  SE05X_EN |        */
 
 
 		builtin-led-gpios = <&ioport4 0 GPIO_ACTIVE_LOW>,

--- a/variants/arduino_portenta_c33_r7fa6m5bh3cfc/variant.h
+++ b/variants/arduino_portenta_c33_r7fa6m5bh3cfc/variant.h
@@ -5,3 +5,5 @@
  */
 
 #pragma once
+
+#define SE05X_ENABLE_GPIO (92u)

--- a/variants/arduino_portenta_h7_stm32h747xx_m7/arduino_portenta_h7_stm32h747xx_m7.overlay
+++ b/variants/arduino_portenta_h7_stm32h747xx_m7/arduino_portenta_h7_stm32h747xx_m7.overlay
@@ -354,7 +354,8 @@ qspi_flash: &mx25l12833f {};
 
 				    <&gpiok 5 0>,		/* LEDR */
 				    <&gpiok 6 0>,		/* LEDG */
-				    <&gpiok 7 0>;		/* LEDB */
+				    <&gpiok 7 0>,		/* LEDB */
+				    <&gpioi 12 0>;		/* SE05X_EN */
 
 		builtin-led-gpios = <&gpiok 6 0>,
 				    <&gpiok 5 0>,

--- a/variants/arduino_portenta_h7_stm32h747xx_m7/variant.h
+++ b/variants/arduino_portenta_h7_stm32h747xx_m7/variant.h
@@ -12,3 +12,5 @@
 #define SS      0
 #define SDA     0
 #define SCL     0
+
+#define SE05X_ENABLE_GPIO (26u)


### PR DESCRIPTION
This will allow to turn se05x on and use it with an arduino library