### PR TITLE
unoq: changed prescaler for timer 1 and timer 8

### DIFF
--- a/variants/arduino_uno_q_stm32u585xx/arduino_uno_q_stm32u585xx.overlay
+++ b/variants/arduino_uno_q_stm32u585xx/arduino_uno_q_stm32u585xx.overlay
@@ -97,7 +97,7 @@
 /* Enable PWM timers */
 &timers1 {
 	status = "okay";
-	st,prescaler = <4>;
+	st,prescaler = <63>;
 
 	pwm1: pwm {
 		status = "okay";
@@ -160,7 +160,7 @@
 /* Currently only the pins marked with ~ on the pin headers are enabled */
 &timers8 {
 	status = "okay";
-	st,prescaler = <4>;
+	st,prescaler = <63>;
 
 	pwm8: pwm {
 		status = "okay";


### PR DESCRIPTION
In actual implementation of UNO Q overlay PSC (prescaler) parameter is set to 4 for all timers.
`timer1` and `timer8` are considered as advanced timers and they are 16bits timers instead of 32bits.
It means that it not possible to achieve low frequency PWM signals due overflow of timer1 and timer8 ARR (autoreload) registers.

To control RC servos it is required to generate a 50Hz wave, so I changed from `4` to `63` the prescaler **only** for `timer1` and `timer8`.
Here a table with some calculations:

ARR | PSC | MCU Frequency | Desired Frequency
-- | -- | -- | --
31 | 4 | 160000000 | 1000000
63999 | 4 | 160000000 | 500
4999 | 63 | 160000000 | 500
49999 | 63 | 160000000 | 50
4 | 63 | 160000000 | 500000
1 | 63 | 160000000 | 1250000

In this case `1.25MHz` is the maximum frequency availble with only 50% duty. 
The `500Hz` frequency used by default in `analogWrite` is still availble up to 12bits resolution.



