### PR TITLE
boards: unoq/giga: add implementation of low-level gpio APIs

### DIFF
--- a/cores/arduino/Arduino.h
+++ b/cores/arduino/Arduino.h
@@ -132,13 +132,21 @@ void noInterrupts(void);
 
 int digitalPinToInterrupt(pin_size_t pin);
 
+// These defines can be overridden by variant.h if implemented
 #define digitalPinToPort(x)    (x)
 #define digitalPinToBitMask(x) (x)
 #define portOutputRegister(x)  (x)
 #define portInputRegister(x)   (x)
 
+const struct device *digitalPinToPortDevice(pin_size_t pinNumber);
+int digitalPinToPinIndex(pin_size_t pinNumber);
+
 #if defined(CONFIG_PWM) || defined(CONFIG_DAC)
 void analogWriteResolution(int bits);
+#endif
+
+#if defined(__arm__)
+#define F_CPU (SystemCoreClock)
 #endif
 
 #include <variant.h>

--- a/cores/arduino/zephyrCommon.cpp
+++ b/cores/arduino/zephyrCommon.cpp
@@ -231,6 +231,18 @@ void yield(void) {
 	k_yield();
 }
 
+const struct device *digitalPinToPortDevice(pin_size_t pinNumber) {
+	RETURN_ON_INVALID_PIN(pinNumber, nullptr);
+
+	return arduino_pins[pinNumber].port;
+}
+
+int digitalPinToPinIndex(pin_size_t pinNumber) {
+	RETURN_ON_INVALID_PIN(pinNumber, -1);
+
+	return arduino_pins[pinNumber].pin;
+}
+
 /*
  *  The ACTIVE_HIGH flag is set so that A low physical
  *  level on the pin will be interpreted as value 0.

--- a/extra/artifacts/_common.inc
+++ b/extra/artifacts/_common.inc
@@ -16,3 +16,4 @@ doc/
 cores/
 libraries/
 variants/_ldscripts/
+variants/common/

--- a/loader/llext_exports.c
+++ b/loader/llext_exports.c
@@ -400,3 +400,7 @@ EXPORT_SYMBOL(arm_irq_disable);
 EXPORT_SYMBOL(arm_irq_is_enabled);
 EXPORT_SYMBOL(arm_irq_priority_set);
 #endif
+
+#if defined(__arm__)
+EXPORT_SYMBOL(SystemCoreClock);
+#endif

--- a/variants/arduino_giga_r1_stm32h747xx_m7/variant.h
+++ b/variants/arduino_giga_r1_stm32h747xx_m7/variant.h
@@ -13,3 +13,5 @@
 #define SS      0
 #define SDA     0
 #define SCL     0
+
+#include "../common/gpio_lowlevel_stm32.h"

--- a/variants/arduino_uno_q_stm32u585xx/variant.h
+++ b/variants/arduino_uno_q_stm32u585xx/variant.h
@@ -39,3 +39,5 @@
 #define LED4_R DIGITAL_PIN_GPIOS_FIND_NODE(DT_NODELABEL(led4_red))
 #define LED4_G DIGITAL_PIN_GPIOS_FIND_NODE(DT_NODELABEL(led4_green))
 #define LED4_B DIGITAL_PIN_GPIOS_FIND_NODE(DT_NODELABEL(led4_blue))
+
+#include "../common/gpio_lowlevel_stm32.h"

--- a/variants/common/gpio_lowlevel_stm32.h
+++ b/variants/common/gpio_lowlevel_stm32.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) Arduino s.r.l. and/or its affiliated companies
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stm32_ll_gpio.h>
+#include <gpio/gpio_stm32.h>
+
+#undef digitalPinToPort
+#undef digitalPinToBitMask
+#undef portOutputRegister
+#undef portInputRegister
+
+#define digitalPinToPort(x)    (GPIO_TypeDef *)(((struct gpio_stm32_config *)(digitalPinToPortDevice(x)->config))->base)
+#define digitalPinToPinName(x) (digitalPinToPinIndex(x))
+#define STM_LL_GPIO_PIN(x)     (1U << x)
+
+#define digitalPinToBitMask(x) STM_LL_GPIO_PIN(x)
+#define portOutputRegister(x)  (digitalPinToPort(x)->ODR)
+#define portInputRegister(x)   (digitalPinToPort(x)->IDR)


### PR DESCRIPTION
Allows compatibility with a broad set of libraries, like Adafruit's NeoPixel