### PR TITLE
unoq: flash bootloader only if really needed

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -278,12 +278,12 @@ tools.remoteocd.path={runtime.tools.remoteocd.path}
 tools.remoteocd.cmd=remoteocd
 tools.remoteocd.upload.params.verbose=--verbose
 tools.remoteocd.upload.params.quiet=
-tools.remoteocd.upload.pattern="{path}/{cmd}" upload --adb-path "{runtime.tools.adb.path}/adb" -s "{upload.port.properties.serialNumber}" -f "{build.variant.path}/{openocd_cfg}" "{upload.verbose}" "{build.path}/{build.project_name}.{upload.extension}" 
+tools.remoteocd.upload.pattern="{path}/{cmd}" upload --adb-path "{runtime.tools.adb.path}/adb" -s "{upload.port.properties.serialNumber}" -f "{build.variant.path}/{openocd_cfg}" "{upload.verbose}" "{runtime.platform.path}/firmwares/{bootloader.file}" "{build.path}/{build.project_name}.{upload.extension}"
 
 tools.remoteocd.bootloader.params.verbose=--verbose
 tools.remoteocd.bootloader.params.quiet=
 tools.remoteocd.erase.pattern=
-tools.remoteocd.bootloader.pattern="{path}/{cmd}" upload --adb-path "{runtime.tools.adb.path}/adb" -s "{upload.port.properties.serialNumber}" -f "{build.variant.path}/flash_bootloader.cfg" "{upload.verbose}" "{runtime.platform.path}/firmwares/{bootloader.file}" 
+tools.remoteocd.bootloader.pattern="{path}/{cmd}" upload --adb-path "{runtime.tools.adb.path}/adb" -s "{upload.port.properties.serialNumber}" -f "{build.variant.path}/flash_bootloader.cfg" "{upload.verbose}" "{runtime.platform.path}/firmwares/{bootloader.file}"
 
 tools.remoteocd_network.upload.protocol=network
 tools.remoteocd_network.upload.field.password=Password
@@ -292,7 +292,7 @@ tools.remoteocd_network.path={runtime.tools.remoteocd.path}
 tools.remoteocd_network.cmd=remoteocd
 tools.remoteocd_network.upload.params.verbose=--verbose
 tools.remoteocd_network.upload.params.quiet=
-tools.remoteocd_network.upload.pattern="{path}/{cmd}" upload -a "{upload.port.address}" --password "{upload.field.password}" -f "{build.variant.path}/{openocd_cfg}" "{upload.verbose}" "{build.path}/{build.project_name}.{upload.extension}" 
+tools.remoteocd_network.upload.pattern="{path}/{cmd}" upload -a "{upload.port.address}" --password "{upload.field.password}" -f "{build.variant.path}/{openocd_cfg}" "{upload.verbose}" "{runtime.platform.path}/firmwares/{bootloader.file}" "{build.path}/{build.project_name}.{upload.extension}"
 
 #
 # PYOCD WRAPPER

--- a/variants/arduino_uno_q_stm32u585xx/flash_bootloader.cfg
+++ b/variants/arduino_uno_q_stm32u585xx/flash_bootloader.cfg
@@ -6,6 +6,8 @@ init
 reset
 halt
 flash info 0
-flash write_image erase ${filename}
+if {[catch {flash verify_image ${filename0}}] != 0} {
+	flash write_image erase ${filename0}
+}
 reset
 shutdown

--- a/variants/arduino_uno_q_stm32u585xx/flash_sketch.cfg
+++ b/variants/arduino_uno_q_stm32u585xx/flash_sketch.cfg
@@ -6,7 +6,12 @@ init
 reset
 halt
 flash info 0
-flash write_image erase ${filename} 0x8100000 bin
+if {[catch {flash verify_image ${filename0}}] != 0} {
+	flash write_image erase ${filename0}
+}
+if {[catch {flash verify_image ${filename1} 0x8100000 bin}] != 0} {
+	flash write_image erase ${filename1} 0x8100000 bin
+}
 reset
 sleep 100
 mww 0x40036400 0xCAFFEEEE


### PR DESCRIPTION
This way the command can be run every time a sketch is being flashed to allow coherency between desktop IDE and AppLab