### PR TITLE
arduino: add Kconfig for delayMicroseconds() compensation

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -38,6 +38,15 @@ config ARDUINO_MAX_TONES
 	  If set to -1 (or any other negative value), the maximum number will be
 	  determined from the system's digital pin configuration.
 
+config ARDUINO_DELAY_US_COMPENSATION
+	int "delayMicroseconds() compensation value (us)"
+	default 1
+	range 0 2147483647
+	help
+	  Compensation value, in microseconds, subtracted from the requested
+	  delay in delayMicroseconds() to account for software overhead.
+	  This can improve short-delay accuracy.
+
 endif
 
 if USB_DEVICE_STACK_NEXT

--- a/cores/arduino/inlines.h
+++ b/cores/arduino/inlines.h
@@ -18,10 +18,16 @@ inline __attribute__((always_inline)) void delay(unsigned long ms) {
 }
 
 inline __attribute__((always_inline)) void delayMicroseconds(unsigned int us) {
+#if CONFIG_ARDUINO_DELAY_US_COMPENSATION < 2
 	if (us == 0) {
 		return;
 	}
-	k_busy_wait(us - 1);
+#else
+	if (us < CONFIG_ARDUINO_DELAY_US_COMPENSATION) {
+		return;
+	}
+#endif
+	k_busy_wait(us - CONFIG_ARDUINO_DELAY_US_COMPENSATION);
 }
 
 #endif /* __INLINES_H__ */


### PR DESCRIPTION
Add CONFIG_ARDUINO_DELAY_US_COMPENSATION for
generalize the delayMicroseconds() compensation.