### PR TITLE
examples: WiFi: use correct HTTP path for example.com

### DIFF
--- a/libraries/WiFi/examples/WiFiWebClient/WiFiWebClient.ino
+++ b/libraries/WiFi/examples/WiFiWebClient/WiFiWebClient.ino
@@ -25,7 +25,7 @@ int status = WL_IDLE_STATUS;
 // if you don't want to use DNS (and reduce your sketch size)
 // use the numeric IP instead of the name for the server:
 // IPAddress server(93,184,216,34);  // IP address for example.com (no DNS)
-char server[] = "example.com";  // host name for example.com (using DNS)
+const char *server = "example.com";  // host name for example.com (using DNS)
 
 ZephyrClient client;
 
@@ -61,7 +61,7 @@ void setup() {
   if (client.connect(server, 80)) {
     Serial.println("connected to server");
     // Make a HTTP request:
-    client.println("GET /index.html HTTP/1.1");
+    client.println("GET / HTTP/1.1");
     client.print("Host: ");
     client.println(server);
     client.println("Connection: close");


### PR DESCRIPTION
The WiFiWebClient example was requesting /index.html from example.com, which returns HTTP 404 Not Found. The correct path is / which returns 200 OK.

**Before**:
`Starting connection to server...
connected to server
HTTP/1.1 404 Not Found
Date: Mon, 20 Apr 2026 11:07:49 GMT
Content-Type: text/html
Transfer-Encoding: chunked
Connection: close
Server: cloudflare
Age: 9805
cf-cache-status: HIT
CF-RAY: 9ef3b0024ff25260-MXP
`

**After**:
`Starting connection to server...
connected to server
HTTP/1.1 200 OK
Date: Mon, 20 Apr 2026 11:05:12 GMT
Content-Type: text/html
Transfer-Encoding: chunked
Connection: close
Server: cloudflare
Last-Modified: Sat, 18 Apr 2026 00:51:00 GMT
Allow: GET, HEAD
Accept-Ranges: bytes
Age: 8727
cf-cache-status: HIT
CF-RAY: 9ef3ac2cbf56ed66-MXP
`

