### PR TITLE
llext: export libc memmem function

### DIFF
--- a/cores/arduino/llext_wrappers.c
+++ b/cores/arduino/llext_wrappers.c
@@ -81,6 +81,7 @@ W3(void *, memset, void *, int, unsigned int)
 W2(char *, strtok, char *, const char *)
 W3(void *, memchr, const void *, int, size_t)
 W1(char *, strdup, const char *)
+W4(void *, memmem, const void *, size_t, const void *, size_t);
 
 /* stdlib.h - conversion */
 W2(double, strtod, const char *, char **)

--- a/loader/CMakeLists.txt
+++ b/loader/CMakeLists.txt
@@ -38,5 +38,6 @@ target_sources_ifdef(CONFIG_USB_DEVICE_STACK_NEXT app PRIVATE
 FILE(GLOB app_sources *.c)
 target_sources(app PRIVATE ${app_sources})
 target_compile_definitions(app PUBLIC _XOPEN_SOURCE=700)
+target_compile_definitions(app PUBLIC _GNU_SOURCE)
 
 target_link_libraries(app PUBLIC blobs)

--- a/loader/llext_exports.c
+++ b/loader/llext_exports.c
@@ -46,6 +46,7 @@ EXPORT_LIBC_SYM(memset);
 EXPORT_LIBC_SYM(strtok);
 EXPORT_LIBC_SYM(memchr);
 EXPORT_LIBC_SYM(strdup);
+EXPORT_LIBC_SYM(memmem);
 
 // stdlib.h
 EXPORT_LIBC_SYM(malloc);


### PR DESCRIPTION
Include missing string.h memmem function in llext_exports.c. This libc function requires _GNU_SOURCE to be defined before including the header string.h, otherwise the function is not defined