### PR TITLE
Ethernet: Improving hardwareStatus method

### DIFF
--- a/libraries/Ethernet/src/Ethernet.cpp
+++ b/libraries/Ethernet/src/Ethernet.cpp
@@ -67,19 +67,15 @@ EthernetLinkStatus EthernetClass::linkStatus() {
 }
 
 EthernetHardwareStatus EthernetClass::hardwareStatus() {
-	const struct device *const dev = DEVICE_DT_GET(DT_COMPAT_GET_ANY_STATUS_OKAY(ethernet_phy));
-	if (device_is_ready(dev)) {
-		for (int i = 1; i < 4; i++) {
-			auto _if = net_if_get_by_index(i);
-			if (_if && !net_eth_type_is_wifi(_if)) {
-				netif = _if;
-				break;
-			}
-		}
-		return EthernetOk;
-	} else {
+	if (netif == nullptr) {
+		netif = net_if_get_first_ethernet();
+	}
+
+	if (netif == nullptr) {
 		return EthernetNoHardware;
 	}
+
+	return EthernetOk;
 }
 
 void EthernetClass::setRetransmissionTimeout(uint16_t milliseconds) {

--- a/loader/llext_exports.c
+++ b/loader/llext_exports.c
@@ -151,6 +151,7 @@ FORCE_EXPORT_SYM(net_if_ipv4_set_netmask);
 FORCE_EXPORT_SYM(net_if_ipv4_set_netmask_by_addr);
 #endif
 FORCE_EXPORT_SYM(net_if_lookup_by_dev);
+FORCE_EXPORT_SYM(net_if_get_first_ethernet);
 #endif
 
 #if defined(CONFIG_NET_L2_ETHERNET)


### PR DESCRIPTION
Using zephyr provided function to retrieve the ethernet interface. Removed the check for ethernet_phy device, since already performed by the ethernet driver