### PR TITLE
variant: portentac33: remove Ethernet clock from user PWM

### DIFF
--- a/variants/arduino_portenta_c33_r7fa6m5bh3cfc/arduino_portenta_c33_r7fa6m5bh3cfc.overlay
+++ b/variants/arduino_portenta_c33_r7fa6m5bh3cfc/arduino_portenta_c33_r7fa6m5bh3cfc.overlay
@@ -301,13 +301,13 @@
                         <&ioport4 0 GPIO_ACTIVE_LOW>,
                         <&ioport8 0 GPIO_ACTIVE_LOW>;
 
-		pwm-pin-gpios =	<&ioport6 0 0>;
+		pwm-pin-gpios =	<>;
 
 		cdc-acm-serial = <&board_cdc_acm_uart>; /* 'Serial' object is managed by SerialUSB */
 		serials = <&uart9>, <&uart7>, <&uart6>, <&uart5>; /* 'Serial1' onwards */
 		i2cs = <&iic0>, <&iic1>, <&i2c3>;
 		spis = <&spi1>;
-		pwms = <&pwm6 1 PWM_HZ(25000000) PWM_POLARITY_NORMAL>;
+		pwms = <>;
 		cans = <&canfd0>;
 
 		io-channels =	<&adc0 6>,


### PR DESCRIPTION
This removes PWM6 from the user-allowed analogWrite() set to prevent potential interference with the Ethernet clock.

The correct PWM frequency (25 MHz) is configured in the board DTS, and the PWM source is started via a system init board callback:
[eth_clock.c](https://github.com/arduino/zephyr/blob/zephyr-arduino-v4.2.0/boards/arduino/portenta_c33/eth_clock.c)

I have not removed P600 from digital-pin-gpios to avoid breaking digital index compatibility.

Note that in Mbed, P600 was configured as an allowed PWM pin in
[variant.cpp](https://github.com/arduino/ArduinoCore-renesas/blob/99f8ee40613b165de124471d9a2b15bf5e2057fb/variants/PORTENTA_C33/variant.cpp#L73)

and it was also configured as an allowed pinmux in
[pinmux.inc](https://github.com/arduino/ArduinoCore-renesas/blob/99f8ee40613b165de124471d9a2b15bf5e2057fb/variants/PORTENTA_C33/pinmux.inc#L366)

Nevertheless, I believe removing it is the correct approach.

There are also other PWM pins currently missing; I will add them in a separate PR to align with the Mbed configuration.