### PR TITLE
variant: portentac33: add pwm configuration for analogWrite

### DIFF
--- a/variants/arduino_portenta_c33_r7fa6m5bh3cfc/arduino_portenta_c33_r7fa6m5bh3cfc.overlay
+++ b/variants/arduino_portenta_c33_r7fa6m5bh3cfc/arduino_portenta_c33_r7fa6m5bh3cfc.overlay
@@ -110,6 +110,39 @@
 	};
 };
 
+
+&pwm3 {
+	status = "okay";
+	pinctrl-0 = <&pwm3_default>;
+	pinctrl-names = "default";
+	interrupts = <65 1>, <66 1>;
+	interrupt-names = "gtioca", "overflow";
+};
+
+&pwm7 {
+	status = "okay";
+	pinctrl-0 = <&pwm7_default>;
+	pinctrl-names = "default";
+	interrupts = <67 1>, <68 1>;
+	interrupt-names = "gtioca", "overflow";
+	/* GPT7 is a 16-bit timer on RA6M5 (BSP_FEATURE_GPT_32BIT_CHANNEL_MASK=0x0F).
+	 * DIV_4 brings PCLKD (120MHz) down to 30MHz, giving period_cycles ~61224
+	 * at 490Hz which fits in 16-bit (65535). */
+	divider = <RA_PWM_SOURCE_DIV_4>;
+};
+
+&pwm8 {
+	status = "okay";
+	pinctrl-0 = <&pwm8_default>;
+	pinctrl-names = "default";
+	interrupts = <69 1>, <70 1>;
+	interrupt-names = "gtioca", "overflow";
+	/* GPT8 is a 16-bit timer on RA6M5 (BSP_FEATURE_GPT_32BIT_CHANNEL_MASK=0x0F).
+	 * DIV_4 brings PCLKD (120MHz) down to 30MHz, giving period_cycles ~61224
+	 * at 490Hz which fits in 16-bit (65535). */
+	divider = <RA_PWM_SOURCE_DIV_4>;
+};
+
 &adc0 {
 	status = "okay";
 	#address-cells = <1>;
@@ -301,13 +334,19 @@
                         <&ioport4 0 GPIO_ACTIVE_LOW>,
                         <&ioport8 0 GPIO_ACTIVE_LOW>;
 
-		pwm-pin-gpios =	<>;
+		pwm-pin-gpios =	<&ioport1 5 0>,
+				    <&ioport1 6 0>,
+				    <&ioport1 11 0>,
+				    <&ioport3 3 0>;
 
 		cdc-acm-serial = <&board_cdc_acm_uart>; /* 'Serial' object is managed by SerialUSB */
 		serials = <&uart9>, <&uart7>, <&uart6>, <&uart5>; /* 'Serial1' onwards */
 		i2cs = <&iic0>, <&iic1>, <&i2c3>;
 		spis = <&spi1>;
-		pwms = <>;
+		pwms = <&pwm1 0 PWM_HZ(490) PWM_POLARITY_NORMAL>,
+		       <&pwm8 1 PWM_HZ(490) PWM_POLARITY_NORMAL>,
+		       <&pwm3 0 PWM_HZ(490) PWM_POLARITY_NORMAL>,
+		       <&pwm7 1 PWM_HZ(490) PWM_POLARITY_NORMAL>;
 		cans = <&canfd0>;
 
 		io-channels =	<&adc0 6>,


### PR DESCRIPTION
This PR adds PWM pin configuration to the Portenta C33 overlay, where `pwm-pin-gpios` and `pwms` were previously empty.

### What was added:

- Enabled Arduino PWM mapping for D0, D1, D2, and D3.
- Set all four channels to the same default PWM frequency used by MBED: [490 Hz](https://github.com/arduino/ArduinoCore-renesas/blob/99f8ee40613b165de124471d9a2b15bf5e2057fb/cores/arduino/FspTimer.h#L10).
- Applied a divider on 16-bit GPT channels (pwm7/pwm8) so 490 Hz fits the hardware counter range.

Note that D4, D5, and D6 are intentionally not configured:

- D4 (P401) maps to GPT6B, which conflicts with the GPT6 resources already used for Ethernet clock generation.
- D5 (P210) is AGT-based PWM, not GPT-based, so it needs a different driver path. While it was supported in Mbed, integration with analogWrite() in this context is not straightforward.
- D6 (P601) maps to GPT6A; GPT6 is shared with Ethernet RMII clock generation (on P600/GPT6B), so enabling it for user PWM would interfere with Ethernet functionality (see #451 ).

### Testing:
Verified that `analogWrite()` provides the expected frequency and duty cycle on the four outputs using spot-check values:

```
analogWrite(D0, 16);
analogWrite(D1, 32);
analogWrite(D2, 48);
analogWrite(D3, 64);
...
analogWrite(D0, 128);
analogWrite(D1, 160);
analogWrite(D2, 192);
analogWrite(D3, 224);
```

<img width="1278" height="723" alt="Portenta_C33_PWM_D0_D3_1" src="https://github.com/user-attachments/assets/5137da23-1d92-44ea-b9bb-63b6ad5b1943" />
<img width="1274" height="721" alt="Portenta_C33_PWM_D0_D3_2" src="https://github.com/user-attachments/assets/f57a47bd-e66c-41d0-b8f8-60cfd4229d2d" />
