### PR TITLE
tools: require sync-zephyr-artifacts 0.2.1

### DIFF
--- a/extra/artifacts/_common.json
+++ b/extra/artifacts/_common.json
@@ -36,7 +36,7 @@
     {
       "packager": "arduino",
       "name": "sync-zephyr-artifacts",
-      "version": "0.1.1"
+      "version": "0.2.1"
     },
     {
       "packager": "arduino",


### PR DESCRIPTION
Update the version of sync-zephyr-artifacts to 0.2.1 in _common.json to import the latest changes with variable file names, core path checks, and API folder processing.