### PR TITLE
variant: nano33ble: fix mbed compatibility for sensor libraries

### DIFF
--- a/variants/arduino_nano_33_ble_nrf52840_sense/variant.h
+++ b/variants/arduino_nano_33_ble_nrf52840_sense/variant.h
@@ -11,3 +11,10 @@
 #define SS      10
 #define SDA     0
 #define SCL     0
+
+/* Arduino_APDS9960 library */
+#define PIN_INT_APDS 26 /* D26 - P0.19 */
+#define APDS9960_INT_PIN PIN_INT_APDS
+#define APDS9960_WIRE_INSTANCE Wire1
+
+#define ARDUINO_ARDUINO_NANO33BLE /* This is required for the proper functioning of some libraries (i.e. Arduino_LPS22HB, Arduino_HS300x. etc. )*/


### PR DESCRIPTION
Add a variant define previously provided by mbed, used by several sensor libraries to correctly select the Wire instance.

Affected libraries:
- [Arduino_APDS9960](https://github.com/arduino-libraries/Arduino_APDS9960/blob/ad3a039db6cf2d63ad3764cf78140d70abe77306/src/Arduino_APDS9960.cpp#L437)
- [Arduino_BMI270_BMM150](https://github.com/arduino-libraries/Arduino_BMI270_BMM150/blob/64c2c7fd834a4821c44c7ba433c349bc0aa1fb6c/src/BMI270.cpp#L574)
- [Arduino_LPS22HB](https://github.com/arduino-libraries/Arduino_LPS22HB/blob/bb7a85d7217ea85b94535c6c0da66eb5e222e331/src/BARO.cpp#L146)
- [Arduino_HS300x](https://github.com/arduino-libraries/Arduino_HS300x/blob/79247c1bd9679ee6afc43880c49ddd47b5f0e397/src/HS300x.cpp#L127)

Note: the `ARDUINO_ARDUINO_NANO33BLE` define is required for compatibility with mbed, where the board build variant name was [`ARDUINO_NANO33BLE`](https://github.com/arduino/ArduinoCore-mbed/blob/f4e981391c698f221ac9ac7146958ed4ad250f17/boards.txt#L242).