### PR TITLE
libraries: RTC: clean up interface, add isRunning()

### DIFF
--- a/libraries/RTC/RTC.cpp
+++ b/libraries/RTC/RTC.cpp
@@ -203,6 +203,26 @@ bool Rtc::begin() {
 }
 
 /**
+ * @brief Checks if the RTC has been configured and is running
+ *
+ * For boards with a dedicated RTC peripheral, verifies that:
+ * 1. The device is ready
+ * 2. A valid time has been set (by attempting to read it)
+ *
+ * @return bool true if RTC is running and has a valid time, false otherwise
+ */
+bool Rtc::isRunning() {
+	if (!device_is_ready(rtc_dev)) {
+		return false;
+	}
+
+	// Try to read the current time to verify it has been set
+	struct rtc_time time;
+	int ret = rtc_get_time(rtc_dev, &time);
+	return ret == 0;
+}
+
+/**
  * @brief Rtc library setter function
  *
  * Used to set the time and data with a single function call
@@ -556,6 +576,15 @@ bool Rtc::begin() {
 }
 
 /**
+ * @brief Checks if the RTC has been configured and is running
+ *
+ * @return bool true if RTC has been initialized with setTime(), false otherwise
+ */
+bool Rtc::isRunning() {
+	return isInitialized;
+}
+
+/**
  * @brief Sets the current RTC time.
  *
  * This function converts a date and time into epoch format and adjusts the
@@ -582,6 +611,7 @@ int Rtc::setTime(int year, int month, int day, int hour, int minute, int second)
 	}
 
 	timeOffset = target - (ticks / freq);
+	isInitialized = true;
 	return 0;
 }
 

--- a/libraries/RTC/RTC.cpp
+++ b/libraries/RTC/RTC.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "RTC.h"
+#include <errno.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
@@ -159,7 +160,8 @@ int Rtc::getSeconds() {
 	return -1;
 }
 
-#if defined(CONFIG_RTC_STM32) || defined(CONFIG_RTC_RPI_PICO)
+#if !defined(CONFIG_COUNTER_NRF_RTC) // For boards with a dedicated RTC peripheral/driver, we use
+									 // the Zephyr RTC
 
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(rtc), okay)
 #define RTC_NODE DT_NODELABEL(rtc)
@@ -408,7 +410,9 @@ void Rtc::alarmCallbackWrapper([[maybe_unused]] const struct device *dev,
  */
 int Rtc::setUpdateCallback(RtcUpdateCallback cb, void *user_data) {
 #if defined(CONFIG_RTC_RPI_PICO)
-	return -1;
+	ARG_UNUSED(cb);
+	ARG_UNUSED(user_data);
+	return -ENOTSUP;
 #else
 	userUpdateCallback = cb;
 	userUpdateCallbackData = user_data;
@@ -445,7 +449,8 @@ void Rtc::updateCallbackWrapper([[maybe_unused]] const struct device *dev, void 
  */
 int Rtc::setCalibration(int32_t calibration) {
 #if defined(CONFIG_RTC_RPI_PICO)
-	return -1;
+	ARG_UNUSED(calibration);
+	return -ENOTSUP;
 #else
 	return rtc_set_calibration(rtc_dev, calibration);
 #endif
@@ -462,14 +467,16 @@ int Rtc::setCalibration(int32_t calibration) {
  */
 int Rtc::getCalibration(int32_t &calibration) {
 #if defined(CONFIG_RTC_RPI_PICO)
-	return -1;
+	ARG_UNUSED(calibration);
+	return -ENOTSUP;
 #else
 	return rtc_get_calibration(rtc_dev, &calibration);
 #endif
 }
 
-#elif defined(CONFIG_COUNTER_NRF_RTC) // For other platforms (nordic), we must use the counter API
-									  // to implement RTC functionality
+#else // For other platforms (i.e. Nordic), we must use the counter API to implement RTC
+	  // functionality
+
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(rtc1), okay)
 #define COUNTER_NODE DT_NODELABEL(rtc1)
 #elif DT_NODE_HAS_STATUS(DT_NODELABEL(rtc2), okay)
@@ -503,8 +510,13 @@ static bool is_leap(int year) {
  */
 void Rtc::alarmHandler(const struct device *dev, uint8_t chan_id, uint32_t ticks, void *user_data) {
 	Rtc *rtc = static_cast<Rtc *>(user_data);
-	if (rtc->user_callback) {
-		rtc->user_callback(dev, chan_id, ticks, rtc->user_data);
+	ARG_UNUSED(dev);
+	ARG_UNUSED(chan_id);
+	ARG_UNUSED(ticks);
+
+	rtc->alarmPending = false;
+	if (rtc->userAlarmCallback) {
+		rtc->userAlarmCallback(rtc->userAlarmCallbackData);
 	} else {
 		printk("Alarm triggered but no callback registered! Channel: %d, Ticks: %u\n", chan_id,
 			   ticks);
@@ -520,8 +532,6 @@ void Rtc::alarmHandler(const struct device *dev, uint8_t chan_id, uint32_t ticks
 Rtc::Rtc() {
 	counter_dev = DEVICE_DT_GET_OR_NULL(COUNTER_NODE);
 	timeOffset = 0;
-	user_callback = nullptr;
-	user_data = nullptr;
 }
 
 /**
@@ -612,14 +622,12 @@ int Rtc::getTime(int &year, int &month, int &day, int &hour, int &minute, int &s
  * @param hour      Target alarm hour.
  * @param minute    Target alarm minute.
  * @param second    Target alarm second.
- * @param callback  Function pointer to the user-defined callback.
- * @param cb_user_data Pointer to user data passed to the callback when triggered.
+ * @param cb        Function pointer to the user-defined callback.
+ * @param user_data Pointer to user data passed to the callback when triggered.
  * @return 0 if successful, or a negative error code if the target time is invalid.
  */
 int Rtc::setAlarm(int year, int month, int day, int hour, int minute, int second,
-				  void (*callback)(const struct device *dev, uint8_t chan_id, uint32_t ticks,
-								   void *user_data),
-				  void *cb_user_data) {
+				  RtcAlarmCallback cb, void *user_data) {
 	time_t target_epoch = datetimeToEpoch(year, month, day, hour, minute, second);
 	uint32_t freq = counter_get_frequency(counter_dev);
 	uint32_t current_ticks;
@@ -639,8 +647,10 @@ int Rtc::setAlarm(int year, int month, int day, int hour, int minute, int second
 	uint32_t alarm_ticks = current_ticks + delta_seconds * freq;
 
 	// Save user callback
-	user_callback = callback;
-	user_data = cb_user_data;
+	userAlarmCallback = cb;
+	userAlarmCallbackData = user_data;
+	alarmEpoch = target_epoch;
+	alarmPending = true;
 
 	alarm_cfg.flags = 0; // Absolute alarm
 	alarm_cfg.ticks = alarm_ticks;
@@ -650,8 +660,10 @@ int Rtc::setAlarm(int year, int month, int day, int hour, int minute, int second
 	int ret = counter_set_channel_alarm(counter_dev, 0, &alarm_cfg);
 	if (ret != 0) {
 		printk("Failed to set alarm: %d\n", ret);
-		user_callback = nullptr;
-		user_data = nullptr;
+		userAlarmCallback = nullptr;
+		userAlarmCallbackData = nullptr;
+		alarmEpoch = 0;
+		alarmPending = false;
 		return ret;
 	}
 
@@ -670,31 +682,36 @@ int Rtc::cancelAlarm() {
 	if (ret != 0) {
 		printk("Failed to cancel alarm: %d\n", ret);
 	}
-	user_callback = nullptr;
-	user_data = nullptr;
+	userAlarmCallback = nullptr;
+	userAlarmCallbackData = nullptr;
+	alarmEpoch = 0;
+	alarmPending = false;
 	return ret;
 }
 
 /**
  * @brief Retrieves the currently configured alarm time.
- * This function is not supported and will return -1 to indicate this.
  *
- * @return -1 to indicate not supported.
+ * @return 0 on success, or a negative error code if no alarm is active.
  */
 int Rtc::getAlarm([[maybe_unused]] int &year, [[maybe_unused]] int &month,
 				  [[maybe_unused]] int &day, [[maybe_unused]] int &hour,
 				  [[maybe_unused]] int &minute, [[maybe_unused]] int &second) {
-	return -1;
+	if (!alarmPending) {
+		return -ENOENT;
+	}
+
+	epochToDatetime(alarmEpoch, year, month, day, hour, minute, second);
+	return 0;
 }
 
 /**
  * @brief Checks whether an alarm is currently pending.
- * This function is not supported and will return false to indicate this.
  *
- * @return false to indicate not supported.
+ * @return true if an alarm is pending, false otherwise.
  */
 bool Rtc::isAlarmPending() {
-	return false;
+	return alarmPending;
 }
 
 /**
@@ -705,7 +722,7 @@ bool Rtc::isAlarmPending() {
  */
 int Rtc::setUpdateCallback([[maybe_unused]] RtcUpdateCallback cb,
 						   [[maybe_unused]] void *user_data) {
-	return -1;
+	return -ENOTSUP;
 }
 
 /**
@@ -715,7 +732,7 @@ int Rtc::setUpdateCallback([[maybe_unused]] RtcUpdateCallback cb,
  * @return -1 to indicate not supported.
  */
 int Rtc::setCalibration([[maybe_unused]] int32_t calibration) {
-	return -1;
+	return -ENOTSUP;
 }
 
 /**
@@ -725,7 +742,7 @@ int Rtc::setCalibration([[maybe_unused]] int32_t calibration) {
  * @return -1 to indicate not supported.
  */
 int Rtc::getCalibration([[maybe_unused]] int32_t &calibration) {
-	return -1;
+	return -ENOTSUP;
 }
 
 /**
@@ -815,6 +832,4 @@ void Rtc::epochToDatetime(time_t t, int &year, int &month, int &day, int &hour, 
 	month = m + 1;
 	day = days + 1;
 }
-#else
-#error "Unsupported RTC configuration"
-#endif /* CONFIG_RTC_STM32 || CONFIG_RTC_RPI_PICO */
+#endif /* !defined(CONFIG_COUNTER) */

--- a/libraries/RTC/RTC.h
+++ b/libraries/RTC/RTC.h
@@ -80,6 +80,13 @@ public:
 	~Rtc();
 
 	/**
+	 * @brief Checks if the RTC device has been configured and is running.
+	 *
+	 * @return true if the RTC is running, false otherwise.
+	 */
+	bool isRunning();
+
+	/**
 	 * @brief Sets the current day of the month in the RTC.
 	 *
 	 * Updates only the day field of the current date and keeps other
@@ -335,6 +342,9 @@ private:
 
 	/** @brief Cached alarm time for counter-backed implementations. */
 	time_t alarmEpoch = 0;
+
+	/** @brief Tracks whether setTime() has been called for CONFIG_COUNTER. */
+	bool isInitialized = false;
 
 	/** @brief Static handler for counter alarm interrupts. */
 	static void alarmHandler(const struct device *dev, uint8_t chan_id, uint32_t ticks,

--- a/libraries/RTC/RTC.h
+++ b/libraries/RTC/RTC.h
@@ -223,7 +223,6 @@ public:
 	 */
 	int getTime(int &year, int &month, int &day, int &hour, int &minute, int &second);
 
-#if defined(CONFIG_RTC_STM32) || defined(CONFIG_RTC_RPI_PICO)
 	/**
 	 * @brief Schedules an alarm for a specific time.
 	 *
@@ -242,79 +241,11 @@ public:
 
 	/**
 	 * @brief Cancels the currently active alarm.
-	 * @return 0 on success, negative error code otherwise.
-	 */
-	int cancelAlarm();
-
-#else
-	/**
-	 * @brief Sets an RTC alarm for boards using the Zephyr counter driver.
-	 *
-	 * @param year Target year.
-	 * @param month Target month.
-	 * @param day Target day.
-	 * @param hour Target hour.
-	 * @param minute Target minute.
-	 * @param second Target second.
-	 * @param callback Function pointer for the alarm event.
-	 * @param cb_user_data Pointer to user data passed to the callback.
-	 * @return 0 on success, negative error code otherwise.
-	 */
-	int setAlarm(int year, int month, int day, int hour, int minute, int second,
-				 void (*callback)(const struct device *dev, uint8_t chan_id, uint32_t ticks,
-								  void *user_data),
-				 void *cb_user_data);
-
-	/**
-	 * @brief Cancels an active alarm.
 	 *
 	 * @return 0 on success, negative error code otherwise.
 	 */
 	int cancelAlarm();
 
-	/**
-	 * @brief Retrieves the currently configured alarm time.
-	 *
-	 * @return -1 to indicate not supported.
-	 */
-	int getAlarm([[maybe_unused]] int &year, [[maybe_unused]] int &month, [[maybe_unused]] int &day,
-				 [[maybe_unused]] int &hour, [[maybe_unused]] int &minute,
-				 [[maybe_unused]] int &second);
-
-	/**
-	 * @brief Checks whether an alarm is currently pending.
-	 * This function is not supported and will return -1 to indicate this.
-	 *
-	 * @return false to indicate not supported.
-	 */
-	bool isAlarmPending();
-
-	/**
-	 * @brief Registers an update callback function.
-	 * This function is not supported and will return -1 to indicate this.
-	 *
-	 * @return -1 to indicate not supported.
-	 */
-	int setUpdateCallback([[maybe_unused]] RtcUpdateCallback cb, [[maybe_unused]] void *user_data);
-
-	/**
-	 * @brief Sets the Rtc calibration value.
-	 * This function is not supported and will return -1 to indicate this.
-	 *
-	 * @return -1 to indicate not supported.
-	 */
-	int setCalibration([[maybe_unused]] int32_t calibration);
-
-	/**
-	 * @brief Retrieves the current Rtc calibration value.
-	 * This function is not supported and will return -1 to indicate this.
-	 *
-	 * @return -1 to indicate not supported.
-	 */
-	int getCalibration([[maybe_unused]] int32_t &calibration);
-#endif
-
-#if defined(CONFIG_RTC_STM32) || defined(CONFIG_RTC_RPI_PICO)
 	/**
 	 * @brief Retrieves the currently configured alarm time.
 	 *
@@ -339,6 +270,7 @@ public:
 	 * @brief Registers an update callback function.
 	 *
 	 * The callback is invoked when the RTC generates an update event.
+	 * Some backends may return `-ENOTSUP` if this feature is unavailable.
 	 *
 	 * @param cb Function pointer for the update callback.
 	 * @param user_data Optional user data passed to the callback.
@@ -349,6 +281,8 @@ public:
 	/**
 	 * @brief Applies a calibration correction to the RTC.
 	 *
+	 * Some backends may return `-ENOTSUP` if this feature is unavailable.
+	 *
 	 * @param calibration Calibration offset in parts per million (ppm).
 	 * @return 0 on success, negative error code otherwise.
 	 */
@@ -357,14 +291,22 @@ public:
 	/**
 	 * @brief Reads the current RTC calibration setting.
 	 *
+	 * Some backends may return `-ENOTSUP` if this feature is unavailable.
+	 *
 	 * @param calibration Reference to store the current calibration value in ppm.
 	 * @return 0 on success, negative error code otherwise.
 	 */
 	int getCalibration(int32_t &calibration);
-#endif
 
 private:
-#if defined(CONFIG_RTC_STM32) || defined(CONFIG_RTC_RPI_PICO)
+	RtcAlarmCallback userAlarmCallback = nullptr; /**< User-registered alarm callback. */
+	void *userAlarmCallbackData = nullptr;        /**< User data for alarm callback. */
+
+	RtcUpdateCallback userUpdateCallback = nullptr; /**< User-registered update callback. */
+	void *userUpdateCallbackData = nullptr;         /**< User data for update callback. */
+
+#if !defined(CONFIG_COUNTER_NRF_RTC) // For boards with a dedicated RTC peripheral/driver, we use
+									 // the Zephyr RTC API directly
 	/** @brief Pointer to the Zephyr RTC device. */
 	const struct device *rtc_dev;
 
@@ -375,15 +317,10 @@ private:
 	/** @brief Internal static wrapper for update callbacks. */
 	static void updateCallbackWrapper([[maybe_unused]] const struct device *dev, void *user_data);
 
-	RtcAlarmCallback userAlarmCallback = nullptr; /**< User-registered alarm callback. */
-	void *userAlarmCallbackData = nullptr;        /**< User data for alarm callback. */
-
-	RtcUpdateCallback userUpdateCallback = nullptr; /**< User-registered update callback. */
-	void *userUpdateCallbackData = nullptr;         /**< User data for update callback. */
-
 	uint16_t alarmId = 0; /**< Default alarm identifier. */
 
-#else // For boards without a dedicated RTC, we use the counter API to implement RTC functionality
+#else // For boards without an RTC driver (i.e. Nordic), we must use the counter API to implement
+	  // RTC functionality
 	/** @brief Pointer to the Zephyr counter device used as RTC backend. */
 	const struct device *counter_dev;
 
@@ -393,12 +330,11 @@ private:
 	/** @brief Counter driver alarm configuration. */
 	struct counter_alarm_cfg alarm_cfg;
 
-	/** @brief User-registered callback for counter-based alarms. */
-	void (*user_callback)(const struct device *dev, uint8_t chan_id, uint32_t ticks,
-						  void *user_data);
+	/** @brief Indicates whether a counter-backed alarm is currently active. */
+	bool alarmPending = false;
 
-	/** @brief User data associated with the alarm callback. */
-	void *user_data;
+	/** @brief Cached alarm time for counter-backed implementations. */
+	time_t alarmEpoch = 0;
 
 	/** @brief Static handler for counter alarm interrupts. */
 	static void alarmHandler(const struct device *dev, uint8_t chan_id, uint32_t ticks,

--- a/libraries/RTC/examples/AlarmRTC/AlarmRTC.ino
+++ b/libraries/RTC/examples/AlarmRTC/AlarmRTC.ino
@@ -26,7 +26,9 @@ void setup() {
     int ret = 0xDEADBEEFu; // Starting with a custom value for the return which will definitely lead to failure if not changed to zero (i.e. success) by the functions below
     char printBuffer[60];
     Serial.begin(115200);
-    delay(1000);
+    while (!Serial) {
+        ; // Wait for Serial to be ready
+    }
 
     if (!rtc.begin()) {
         Serial.println("RTC not ready\n");

--- a/libraries/RTC/examples/AlarmRTC/AlarmRTC.ino
+++ b/libraries/RTC/examples/AlarmRTC/AlarmRTC.ino
@@ -16,20 +16,11 @@ Rtc rtc;
 char printBuffer[30]; // declare a buffer of large enough size for the message we want to display
 int year, month, day, hour, minute, second;
 
-#if defined(ARDUINO_NICLA_SENSE_ME) || defined(ARDUINO_NANO33BLE)
-void onAlarm(const struct device *dev, uint8_t chan_id, uint32_t ticks, void *user_data) {
-    char printBuffer[40];
-    // Assuming user_data is a string or message you want to print
-    sprintf(printBuffer, "Alarm went off! Message: %s\n", (char *)user_data);
-    Serial.println(printBuffer);
-}
-#else
 void onAlarm(void *user_data) {
     char printBuffer[40];
     sprintf(printBuffer, "Alarm went off! Message: %s\n", (char *)user_data);
     Serial.println(printBuffer);
 }
-#endif
 
 void setup() {
     int ret = 0xDEADBEEFu; // Starting with a custom value for the return which will definitely lead to failure if not changed to zero (i.e. success) by the functions below

--- a/libraries/RTC/examples/CalibrationRTC/CalibrationRTC.ino
+++ b/libraries/RTC/examples/CalibrationRTC/CalibrationRTC.ino
@@ -13,6 +13,9 @@ void setup() {
     char printBuffer[64];
     delay(1000);
     Serial.begin(115200);
+    while (!Serial) {
+        ; // Wait for Serial to be ready
+    }
     if (!rtc.begin()) {
         printf("RTC not ready\n");
         return;

--- a/libraries/RTC/examples/SimpleRTC/SimpleRTC.ino
+++ b/libraries/RTC/examples/SimpleRTC/SimpleRTC.ino
@@ -14,11 +14,17 @@ char printBuffer[30];               // Allocate large enough buffer to hold the 
 
 void setup() {
     Serial.begin(115200);
+    while (!Serial) {
+        ; // Wait for Serial to be ready
+    }
     if (!rtc.begin()) {
         Serial.println("RTC not ready\n");
         return;
     }
-    rtc.setTime(2025, 10, 21, 12, 0, 0);
+    if (!rtc.isRunning()) {
+        Serial.println("RTC is not running, setting initial time to 2025-10-21 12:00:00\n");
+        rtc.setTime(2025, 10, 21, 12, 0, 0);
+    }
 }
 
 void loop() {


### PR DESCRIPTION
- Improve `void onAlarm(void *user_data)` callback to use the same signature across all underlying boards/RTC implementations.

- Add i`sRunning()` interface to determine whether the RTC is configured and running.