### PR TITLE
core: pinmux: Use device_init()/device_deinit()

### DIFF
--- a/cores/arduino/zephyrCommon.cpp
+++ b/cores/arduino/zephyrCommon.cpp
@@ -17,7 +17,7 @@ void _reinit_peripheral_if_needed(pin_size_t pin, const struct device *dev) {
 	if (pinmux_array[pin] != dev) {
 		pinmux_array[pin] = dev;
 		if (dev != NULL) {
-			dev->ops.init(dev);
+			device_init(dev);
 		}
 	}
 }

--- a/cores/arduino/zephyrSerial.h
+++ b/cores/arduino/zephyrSerial.h
@@ -76,11 +76,7 @@ public:
 	void flush();
 
 	void end() {
-#ifdef CONFIG_DEVICE_DEINIT_SUPPORT
-		if (uart->ops.deinit) {
-			uart->ops.deinit(uart);
-		}
-#endif
+		device_deinit(uart);
 	}
 
 	size_t write(const uint8_t *buffer, size_t size);
@@ -110,7 +106,7 @@ protected:
 	ZephyrSerialBuffer<CONFIG_ARDUINO_API_SERIAL_BUFFER_SIZE> rx;
 
 	virtual void _reinit_if_needed() {
-		uart->ops.init(uart);
+		device_init(uart);
 	}
 };
 

--- a/libraries/SPI/SPI.cpp
+++ b/libraries/SPI/SPI.cpp
@@ -115,15 +115,11 @@ void arduino::ZephyrSPI::detachInterrupt() {
 }
 
 void arduino::ZephyrSPI::begin() {
-	spi_dev->ops.init(spi_dev);
+	device_init(spi_dev);
 }
 
 void arduino::ZephyrSPI::end() {
-#ifdef CONFIG_DEVICE_DEINIT_SUPPORT
-	if (spi_dev->ops.deinit) {
-		spi_dev->ops.deinit(spi_dev);
-	}
-#endif
+	device_deinit(spi_dev);
 }
 
 #if DT_NODE_HAS_PROP(DT_PATH(zephyr_user), spis)

--- a/libraries/Wire/Wire.cpp
+++ b/libraries/Wire/Wire.cpp
@@ -57,7 +57,7 @@ arduino::ZephyrI2C::ZephyrI2C(const struct device *i2c) : i2c_cfg({0}), i2c_dev(
 }
 
 void arduino::ZephyrI2C::begin() {
-	i2c_dev->ops.init(i2c_dev);
+	device_init(i2c_dev);
 }
 
 void arduino::ZephyrI2C::begin(uint8_t slaveAddr) {
@@ -74,11 +74,7 @@ void arduino::ZephyrI2C::end() {
 		i2c_target_unregister(i2c_dev, &i2c_cfg);
 		memset(&i2c_cfg, 0, sizeof(i2c_cfg));
 	}
-#ifdef CONFIG_DEVICE_DEINIT_SUPPORT
-	if (i2c_dev->ops.deinit) {
-		i2c_dev->ops.deinit(i2c_dev);
-	}
-#endif
+	device_deinit(i2c_dev);
 }
 
 void arduino::ZephyrI2C::setClock(uint32_t freq) {


### PR DESCRIPTION
Calling device_init()/device_deinit() instead of calling ops.init/ops.deinit directry.

This is keep correctly device internal state.