### PR TITLE
libraries: SPI: fix include of the removed header

### DIFF
--- a/libraries/SPI/SPI.cpp
+++ b/libraries/SPI/SPI.cpp
@@ -5,7 +5,6 @@
  */
 
 #include "SPI.h"
-#include "zephyrInternal.h"
 #include <zephyr/kernel.h>
 
 arduino::ZephyrSPI::ZephyrSPI(const struct device *spi) : spi_dev(spi) {


### PR DESCRIPTION
This fixes the removal of the header in PR #375