### PR TITLE
ci: fix SPI tests in CI + minor hotfixes

### DIFF
--- a/.github/workflows/package_core.yml
+++ b/.github/workflows/package_core.yml
@@ -15,7 +15,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.actor }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name != 'push' || github.repository != 'arduino/ArduinoCore-zephyr' }}
 
 env:
   # use the head SHA for PR hashes, instead of the merge commit

--- a/.github/workflows/package_core.yml
+++ b/.github/workflows/package_core.yml
@@ -440,7 +440,7 @@ jobs:
       - name: Compute code size changes
         if: ${{ github.event_name == 'pull_request' }}
         run: |
-          export GITHUB_BASE_SHA=$(git describe --always origin/${GITHUB_BASE_REF})
+          export GITHUB_BASE_SHA=$(git rev-list --parents -n 1 HEAD | cut -d' ' -f2)
           # errors due to race conditions with parallel branch runs should not fail the job
           extra/ci_calc_size_reports.py ${GITHUB_BASE_SHA} sketches-reports/ || true
 

--- a/.github/workflows/package_core.yml
+++ b/.github/workflows/package_core.yml
@@ -7,6 +7,10 @@ name: Package, test and upload core
 
 on:
   push:
+    branches:
+      - '**'
+    tags-ignore:
+      - 'tools/**' # do not run on tags created for tool releases
   pull_request:
 
 concurrency:

--- a/.github/workflows/package_core.yml
+++ b/.github/workflows/package_core.yml
@@ -139,16 +139,19 @@ jobs:
           (cd ~ && tar --use-compress-program=unzstd -xpf build-env.tar.zstd && rm build-env.tar.zstd)
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.21
+        uses: actions/cache@v5
         with:
-          verbose: 1
           key: ${{ github.job }}-${{ matrix.board }} # independent caches
+          path: ~/.cache/ccache
 
       - name: Build loader
         shell: bash
         run: |
           # create the report directory
           mkdir -p reports
+          echo "::group::ccache stats before build"
+          ccache --show-stats
+          echo "::endgroup::"
           # run the build, capturing stdout and stderr
           if ! ./extra/build.sh ${{ matrix.board }} 1> >(tee $REPORT.stdout) 2> >(tee $REPORT.stderr) ; then
             # build failed, capture errors in summary and stop job without artifacts
@@ -172,7 +175,12 @@ jobs:
                              | awk 'BEGIN {split("B KB MB GB", u); for(i in u) m[u[i]]=1024^(i-1)} /:/ {print "[\"" $1 "\"," $2*m[$3] "," $4*m[$5] "]"}' \
                              | sort \
                              | jq -s "map((select(.[0] == \"FLASH:\") | .[2]) |= ${LOADER_SIZE}) + [ [ \"SKETCH:\", 0, ${SKETCH_SIZE} ] ]" > $REPORT.meminfo
-          jq
+
+          # ccache stats update
+          echo "::group::ccache stats after build"
+          ccache --evict-older-than 30d
+          ccache --show-stats
+          echo "::endgroup::"
 
       - name: Package board artifacts
         if: ${{ !cancelled() }}

--- a/.github/workflows/package_core.yml
+++ b/.github/workflows/package_core.yml
@@ -423,6 +423,8 @@ jobs:
         run: |
           # gather the array of job metadata (especially name and ID) for the current workflow run
           export WORKFLOW_JOBS=$(gh run view ${{ github.run_id }} --attempt ${{ github.run_attempt }} --json jobs --jq '.jobs')
+          # Archive the input set of reports for later inspection
+          tar jchf build-reports-${{ needs.build-env.outputs.CORE_HASH }}.tar.bz2 zephyr-* arduino-*.json
           # Run the log inspection script
           extra/ci_inspect_logs.py result summary full_log
           cat result
@@ -471,12 +473,21 @@ jobs:
           retention-days: 1
 
       # upload new official test size artifact (for AWS storage)
-      - name: Archive sketch report information
+      - name: Archive sketch size information
         uses: actions/upload-artifact@v7
         if: ${{ github.event_name == 'push' }}
         with:
           name: size-reports
           path: size-reports-${{ needs.build-env.outputs.CORE_HASH }}.tar.bz2
+          retention-days: 1
+          archive: false
+
+      # upload input set of build reports artifact (for CI debugging)
+      - name: Archive input test reports
+        uses: actions/upload-artifact@v7
+        with:
+          name: build-reports
+          path: build-reports-${{ needs.build-env.outputs.CORE_HASH }}.tar.bz2
           retention-days: 1
           archive: false
 

--- a/.github/workflows/package_tool.yml
+++ b/.github/workflows/package_tool.yml
@@ -108,7 +108,6 @@ jobs:
           name: ${{ matrix.tool }}-${{ matrix.version }}.json
           path: distrib/*.json
           archive: false
-          retention-days: 7
 
   # Upload the built tool packages to the S3 bucket for public distribution.
 

--- a/extra/artifacts/_common.test_setup.sh
+++ b/extra/artifacts/_common.test_setup.sh
@@ -27,5 +27,5 @@ else
 	get_latest_release libraries arduino-libraries/Arduino_JSON \
 
 	# Smoke test for SPI API compatibilty
-	# get_branch_tip libraries PaulStoffregen/SerialFlash master
+	get_branch_tip libraries stefandz/M95M01 master
 fi

--- a/extra/artifacts/zephyr_unoq.test_setup.sh
+++ b/extra/artifacts/zephyr_unoq.test_setup.sh
@@ -20,7 +20,15 @@ get_branch_tip libraries arduino-libraries/ArduinoBLE master \
 	examples/Peripheral/ButtonLED \
 
 # Arduino_RouterBridge
-get_branch_tip libraries arduino-libraries/Arduino_RouterBridge main
+get_branch_tip libraries arduino-libraries/Arduino_RouterBridge main \
+	examples/client \
+	examples/hci \
+	examples/monitor \
+	examples/server \
+	examples/udp_ntp_client \
 
 # Arduino_RPClite
-get_branch_tip libraries arduino-libraries/Arduino_RPClite main
+get_branch_tip libraries arduino-libraries/Arduino_RPClite main \
+	examples/rpc_lite_client \
+	examples/rpc_lite_server \
+

--- a/extra/ci_test_list.sh
+++ b/extra/ci_test_list.sh
@@ -99,7 +99,6 @@ find ArduinoCore-zephyr/libraries/ -name library.properties | while read -r prop
 		[ -z "$dep" ] || printf " - name: \"%s\"\n" "$dep" >> $GITHUB_ENV
 	done
 done
-printf " - source-path: \"%s\"\n" $(find ArduinoCore-zephyr/libraries/ -maxdepth 1 -mindepth 1 -type d) >> $GITHUB_ENV
 echo "EOF" >> $GITHUB_ENV
 
 if [ -f $VARIANT_DIR/skip_these_examples.txt ] ; then

--- a/extra/ci_test_list.sh
+++ b/extra/ci_test_list.sh
@@ -9,6 +9,8 @@
 #
 # The core under test should be extracted in the 'ArduinoCore-zephyr' subdirectory.
 
+set -e
+
 if [ "$#" -lt 2 ] ; then
 	echo "Usage: $0 <artifact> <variant> [<additional_library_paths>...]"
 	exit 1
@@ -60,9 +62,11 @@ get_latest_release() {
 	local url=$(curl -s "https://api.github.com/repos/${repo}/releases/latest" | jq -r '.tarball_url')
 	shift 2
 
-	echo "Getting latest release for ${repo}"
+	echo "::group::Getting latest release for ${repo}"
 
 	fetch_and_extract "$url" "*-${project}-*" "ArduinoCore-zephyr/${folder}/${project}" "$@"
+
+	echo "::endgroup::"
 }
 
 get_branch_tip() {
@@ -73,9 +77,11 @@ get_branch_tip() {
 	local url="https://github.com/${repo}/archive/refs/heads/${branch}.tar.gz"
 	shift 3
 
-	echo "Getting branch ${branch} of ${repo}"
+	echo "::group::Getting branch ${branch} of ${repo}"
 
 	fetch_and_extract "$url" "${project}-${branch}" "ArduinoCore-zephyr/${folder}/${project}" "$@"
+
+	echo "::endgroup::"
 }
 
 ALL_TESTS=$(mktemp)

--- a/variants/arduino_nicla_sense_me_nrf52832/arduino_nicla_sense_me_nrf52832.overlay
+++ b/variants/arduino_nicla_sense_me_nrf52832/arduino_nicla_sense_me_nrf52832.overlay
@@ -60,6 +60,6 @@
 
 		serials = <&uart0>;
 		i2cs = <&i2c1>;
-		spis = <>; /* spi0, conflicts with uart0 */
+		// spis = <&spi0>; // conflicts with uart0 (same peripheral)
 	};
 };

--- a/variants/arduino_nicla_sense_me_nrf52832/skip_these_examples.txt
+++ b/variants/arduino_nicla_sense_me_nrf52832/skip_these_examples.txt
@@ -18,3 +18,6 @@ libraries/Storage
 libraries/WiFi
 libraries/Zephyr_SDRAM
 libraries/CAN
+
+# SPI peripheral on Nicla Sense conflicts with UART0
+libraries/M95M01

--- a/variants/arduino_opta_stm32h747xx_m7/skip_these_examples.txt
+++ b/variants/arduino_opta_stm32h747xx_m7/skip_these_examples.txt
@@ -11,3 +11,6 @@
 libraries/Camera
 libraries/Zephyr_SDRAM
 libraries/CAN
+
+# no SPI on Opta
+libraries/M95M01


### PR DESCRIPTION
* fix SPI support and enable CI tests
* raise an error if a scheduled test was not obtained properly
* keep JSONs related to tools for 90 days
* fix memory footprint report fluctuations by extracting the merge reference from the Git commit
* use standard `actions/cache` action with stable caches 
* fix "Multiple libs found" message in compile-sketches results
* export an archive of all test logs for CI debugging purposes
* reduce the number of tests run for UNO Q RPC and Bridge
* fix the `package_core` workflow to not run on tool tags, potentially corrupting binaries  
* fix the `package_core` workflow  to always complete push runs on the main repo, because we need all the artifacts

Last CI run [here](https://github.com/arduino/ArduinoCore-zephyr/actions/runs/25516423481?pr=469).