### PR TITLE
core: PWM/ADC constants make into `constexpr`

### DIFF
--- a/cores/arduino/wiring_analog.cpp
+++ b/cores/arduino/wiring_analog.cpp
@@ -35,13 +35,6 @@ namespace {
 
 #ifdef CONFIG_PWM
 
-const struct pwm_dt_spec arduino_pwm[] = {
-	DT_FOREACH_PROP_ELEM(DT_PATH(zephyr_user), pwms, PWM_DT_SPEC)};
-
-/* pwm-pins node provides a mapping digital pin numbers to pwm channels */
-const pin_size_t arduino_pwm_pins[] = {
-	DT_FOREACH_PROP_ELEM(DT_PATH(zephyr_user), pwm_pin_gpios, PWM_PINS)};
-
 size_t pwm_pin_index(pin_size_t pinNumber) {
 	for (size_t i = 0; i < ARRAY_SIZE(arduino_pwm_pins); i++) {
 		if (arduino_pwm_pins[i] == pinNumber) {
@@ -54,13 +47,6 @@ size_t pwm_pin_index(pin_size_t pinNumber) {
 #endif // CONFIG_PWM
 
 #ifdef CONFIG_ADC
-
-const struct adc_dt_spec arduino_adc[] = {
-	DT_FOREACH_PROP_ELEM(DT_PATH(zephyr_user), io_channels, ADC_DT_SPEC)};
-
-/* io-channel-pins node provides a mapping digital pin numbers to adc channels */
-const pin_size_t arduino_analog_pins[] = {
-	DT_FOREACH_PROP_ELEM(DT_PATH(zephyr_user), adc_pin_gpios, ADC_PINS)};
 
 struct adc_channel_cfg channel_cfg[] = {
 	DT_FOREACH_PROP_ELEM(DT_PATH(zephyr_user), io_channels, ADC_CH_CFG)};

--- a/cores/arduino/wiring_private.h
+++ b/cores/arduino/wiring_private.h
@@ -15,6 +15,16 @@
 		}                                                                                          \
 	} while (0)
 
+#define ZARD_PWM_DT_SPEC(n, p, i) PWM_DT_SPEC_GET_BY_IDX(n, i),
+#define ZARD_PWM_PINS(n, p, i)                                                                     \
+	DIGITAL_PIN_GPIOS_FIND_PIN(DT_REG_ADDR(DT_PHANDLE_BY_IDX(DT_PATH(zephyr_user), p, i)),         \
+							   DT_PHA_BY_IDX(DT_PATH(zephyr_user), p, i, pin)),
+
+#define ZARD_ADC_DT_SPEC(n, p, i) ADC_DT_SPEC_GET_BY_IDX(n, i),
+#define ZARD_ADC_PINS(n, p, i)                                                                     \
+	DIGITAL_PIN_GPIOS_FIND_PIN(DT_REG_ADDR(DT_PHANDLE_BY_IDX(DT_PATH(zephyr_user), p, i)),         \
+							   DT_PHA_BY_IDX(DT_PATH(zephyr_user), p, i, pin)),
+
 #ifdef __cplusplus
 
 namespace zephyr {
@@ -23,6 +33,28 @@ namespace arduino {
 constexpr struct gpio_dt_spec arduino_pins[] = {
 	DT_FOREACH_PROP_ELEM_SEP(
 	DT_PATH(zephyr_user), digital_pin_gpios, GPIO_DT_SPEC_GET_BY_IDX, (, ))};
+
+#ifdef CONFIG_PWM
+
+constexpr struct pwm_dt_spec arduino_pwm[] = {
+	DT_FOREACH_PROP_ELEM(DT_PATH(zephyr_user), pwms, ZARD_PWM_DT_SPEC)};
+
+/* pwm-pins node provides a mapping digital pin numbers to pwm channels */
+constexpr pin_size_t arduino_pwm_pins[] = {
+	DT_FOREACH_PROP_ELEM(DT_PATH(zephyr_user), pwm_pin_gpios, ZARD_PWM_PINS)};
+
+#endif
+
+#ifdef CONFIG_ADC
+
+constexpr struct adc_dt_spec arduino_adc[] = {
+	DT_FOREACH_PROP_ELEM(DT_PATH(zephyr_user), io_channels, ZARD_ADC_DT_SPEC)};
+
+/* io-channel-pins node provides a mapping digital pin numbers to adc channels */
+constexpr pin_size_t arduino_analog_pins[] = {
+	DT_FOREACH_PROP_ELEM(DT_PATH(zephyr_user), adc_pin_gpios, ZARD_ADC_PINS)};
+
+#endif
 
 /*
  * Calculate GPIO ports/pins number statically from devicetree configuration


### PR DESCRIPTION
Move the constant array derived from devicetree to wiring_private.h and convert it to constexpr.