### PR TITLE
llext: use naked trampolines for compiler ABI helpers

### DIFF
--- a/cores/arduino/llext_wrappers.c
+++ b/cores/arduino/llext_wrappers.c
@@ -62,6 +62,24 @@
 		__real_##name(a);                                                                          \
 	}
 
+/*
+ * Naked trampoline for compiler ABI helpers (__aeabi_*).
+ *
+ * ARM RTABI passes doubles in core registers r0:r1 / r2:r3 regardless of
+ * -mfloat-abi=hard. A C wrapper compiled with -Os generates "ldr r3, [pc, #0]"
+ * which clobbers r3 (the high-word of the second double argument) before the
+ * tail-call, corrupting the comparison result.
+ *
+ * The naked trampoline uses r12 (ip, AAPCS inter-procedure scratch register)
+ * which is never an argument register, so r0–r3 and d0–d7 are untouched.
+ */
+#define VN(name)                                                                                   \
+	__attribute__((naked)) void name(void) {                                                       \
+		__asm__("movw r12, #:lower16:__real_" #name "\n\t"                                         \
+				"movt r12, #:upper16:__real_" #name "\n\t"                                         \
+				"bx   r12");                                                                       \
+	}
+
 /* string.h */
 W3(void *, memcpy, void *, const void *, size_t)
 W3(void *, memmove, void *, const void *, size_t)
@@ -144,9 +162,42 @@ W1(float, sinf, float)
 W1(float, sqrtf, float)
 W1(float, tanf, float)
 
-/* compiler double helper functions */
-W2(double, __aeabi_dadd, double, double)
-W2(int, __aeabi_dcmpgt, double, double)
+/* compiler ABI helpers: need to preserve all RTABI argument registers */
+/* double arithmetic */
+VN(__aeabi_dadd)
+VN(__aeabi_dsub)
+VN(__aeabi_dmul)
+VN(__aeabi_ddiv)
+/* double comparisons */
+VN(__aeabi_dcmpeq)
+VN(__aeabi_dcmplt)
+VN(__aeabi_dcmple)
+VN(__aeabi_dcmpgt)
+VN(__aeabi_dcmpge)
+VN(__aeabi_dcmpun)
+/* float comparisons */
+VN(__aeabi_fcmple)
+VN(__aeabi_fcmpun)
+/* double <-> integer conversions */
+VN(__aeabi_d2iz)
+VN(__aeabi_d2uiz)
+VN(__aeabi_d2lz)
+VN(__aeabi_i2d)
+VN(__aeabi_ui2d)
+VN(__aeabi_l2d)
+VN(__aeabi_ul2d)
+/* float <-> double / integer conversions */
+VN(__aeabi_d2f)
+VN(__aeabi_f2d)
+VN(__aeabi_l2f)
+VN(__aeabi_ul2f)
+/* integer division */
+VN(__aeabi_idiv)
+VN(__aeabi_uidiv)
+VN(__aeabi_idivmod)
+VN(__aeabi_uidivmod)
+VN(__aeabi_ldivmod)
+VN(__aeabi_uldivmod)
 
 /* stdio.h */
 W1(int, puts, const char *)

--- a/loader/llext_exports.c
+++ b/loader/llext_exports.c
@@ -15,9 +15,9 @@
 #include <zephyr/kernel.h>
 #include <time.h>
 
-#define FORCE_EXPORT_SYM(name) \
-       extern void name(void); \
-       EXPORT_SYMBOL(name);
+#define FORCE_EXPORT_SYM(name)                                                                     \
+	extern void name(void);                                                                        \
+	EXPORT_SYMBOL(name);
 
 /*
  * Libc functions are exported with a __real_ prefix so that the sketch
@@ -26,6 +26,14 @@
  * fail when the LLEXT is loaded in a different memory region (>16 MB away).
  */
 #define EXPORT_LIBC_SYM(name) EXPORT_SYMBOL_NAMED(name, __real_##name)
+
+/*
+ * ARM RTABI __aeabi_* functions need naked assembly trampolines to avoid
+ * corrupting argument registers with standard C function prologue/epilogue.
+ */
+#define EXPORT_AEABI_SYM(name)                                                                     \
+	extern void name(void);                                                                        \
+	EXPORT_LIBC_SYM(name)
 
 // string.h
 EXPORT_LIBC_SYM(memcpy);
@@ -283,8 +291,8 @@ EXPORT_SYMBOL(k_work_schedule_for_queue);
 EXPORT_SYMBOL(k_work_reschedule_for_queue);
 EXPORT_SYMBOL(k_work_queue_start);
 EXPORT_SYMBOL(k_work_submit_to_queue);
-//FORCE_EXPORT_SYM(k_timer_user_data_set);
-//FORCE_EXPORT_SYM(k_timer_start);
+// FORCE_EXPORT_SYM(k_timer_user_data_set);
+// FORCE_EXPORT_SYM(k_timer_start);
 
 EXPORT_SYMBOL(time);
 EXPORT_SYMBOL(sys_clock_settime);
@@ -309,39 +317,45 @@ EXPORT_SYMBOL(ring_buf_area_finish);
 #endif
 
 EXPORT_SYMBOL(sys_clock_cycle_get_32);
-FORCE_EXPORT_SYM(__aeabi_dcmpun);
-FORCE_EXPORT_SYM(__aeabi_dcmple);
-FORCE_EXPORT_SYM(__aeabi_d2lz);
-FORCE_EXPORT_SYM(__aeabi_uldivmod);
-FORCE_EXPORT_SYM(__aeabi_ui2d);
-FORCE_EXPORT_SYM(__aeabi_dcmplt);
-FORCE_EXPORT_SYM(__aeabi_ddiv);
-FORCE_EXPORT_SYM(__aeabi_dmul);
-FORCE_EXPORT_SYM(__aeabi_d2f);
-FORCE_EXPORT_SYM(__aeabi_fcmpun);
-extern double __aeabi_dadd(double, double);
-EXPORT_LIBC_SYM(__aeabi_dadd);
-FORCE_EXPORT_SYM(__aeabi_fcmple);
-FORCE_EXPORT_SYM(__aeabi_idiv);
-extern int __aeabi_dcmpgt(double, double);
-EXPORT_LIBC_SYM(__aeabi_dcmpgt);
-FORCE_EXPORT_SYM(__aeabi_dsub);
-FORCE_EXPORT_SYM(__aeabi_i2d);
-FORCE_EXPORT_SYM(__aeabi_uidiv);
-FORCE_EXPORT_SYM(__aeabi_l2d);
-FORCE_EXPORT_SYM(__aeabi_d2uiz);
-FORCE_EXPORT_SYM(__aeabi_uidivmod);
-FORCE_EXPORT_SYM(__aeabi_dcmpeq);
-FORCE_EXPORT_SYM(__aeabi_d2iz);
-FORCE_EXPORT_SYM(__aeabi_f2d);
-FORCE_EXPORT_SYM(__aeabi_ul2d);
-FORCE_EXPORT_SYM(__aeabi_l2f);
-FORCE_EXPORT_SYM(__aeabi_idivmod);
-FORCE_EXPORT_SYM(__aeabi_ldivmod);
-FORCE_EXPORT_SYM(__aeabi_ul2f);
-FORCE_EXPORT_SYM(__aeabi_dcmpge);
 
-#if defined (CONFIG_CPP)
+/* compiler ABI helpers: exported as __real_##name for VN() trampolines in llext_wrappers.c */
+/* double arithmetic */
+EXPORT_AEABI_SYM(__aeabi_dadd);
+EXPORT_AEABI_SYM(__aeabi_dsub);
+EXPORT_AEABI_SYM(__aeabi_dmul);
+EXPORT_AEABI_SYM(__aeabi_ddiv);
+/* double comparisons */
+EXPORT_AEABI_SYM(__aeabi_dcmpeq);
+EXPORT_AEABI_SYM(__aeabi_dcmplt);
+EXPORT_AEABI_SYM(__aeabi_dcmple);
+EXPORT_AEABI_SYM(__aeabi_dcmpgt);
+EXPORT_AEABI_SYM(__aeabi_dcmpge);
+EXPORT_AEABI_SYM(__aeabi_dcmpun);
+/* float comparisons */
+EXPORT_AEABI_SYM(__aeabi_fcmple);
+EXPORT_AEABI_SYM(__aeabi_fcmpun);
+/* double <-> integer conversions */
+EXPORT_AEABI_SYM(__aeabi_d2iz);
+EXPORT_AEABI_SYM(__aeabi_d2uiz);
+EXPORT_AEABI_SYM(__aeabi_d2lz);
+EXPORT_AEABI_SYM(__aeabi_i2d);
+EXPORT_AEABI_SYM(__aeabi_ui2d);
+EXPORT_AEABI_SYM(__aeabi_l2d);
+EXPORT_AEABI_SYM(__aeabi_ul2d);
+/* float <-> double / integer conversions */
+EXPORT_AEABI_SYM(__aeabi_d2f);
+EXPORT_AEABI_SYM(__aeabi_f2d);
+EXPORT_AEABI_SYM(__aeabi_l2f);
+EXPORT_AEABI_SYM(__aeabi_ul2f);
+/* integer division */
+EXPORT_AEABI_SYM(__aeabi_idiv);
+EXPORT_AEABI_SYM(__aeabi_uidiv);
+EXPORT_AEABI_SYM(__aeabi_idivmod);
+EXPORT_AEABI_SYM(__aeabi_uidivmod);
+EXPORT_AEABI_SYM(__aeabi_ldivmod);
+EXPORT_AEABI_SYM(__aeabi_uldivmod);
+
+#if defined(CONFIG_CPP)
 FORCE_EXPORT_SYM(__cxa_pure_virtual);
 #endif
 


### PR DESCRIPTION
The compiler's `__aeabi_`* helper functions for double arithmetic and comparisons use the AAPCS calling convention which passes arguments in core registers `r0`–`r3` and `d0`–`d7` regardless of `-mfloat-abi=hard`. However, the current C wrappers for these functions generated standard C code that clobbered r3 (the high-word of the second double argument) before the tail-call, corrupting the comparison result and causing undefined behavior.

This commit replaces the C wrappers with naked trampolines that preserve all RTABI argument registers, allowing the kernel's implementations of the `__aeabi_`* functions to be called without corrupting arguments.