### PR TITLE
cores: unoq: add Serial3 same pins as Wire (SCL/SDA)

### DIFF
--- a/variants/arduino_uno_q_stm32u585xx/arduino_uno_q_stm32u585xx.overlay
+++ b/variants/arduino_uno_q_stm32u585xx/arduino_uno_q_stm32u585xx.overlay
@@ -255,6 +255,18 @@
 	status = "okay";
 };
 
+&usart3_rx_pb11 {
+	bias-pull-up;
+};
+
+&usart3 {
+	status = "okay";
+	zephyr,deferred-init;
+	pinctrl-0 = <&usart3_tx_pb10 &usart3_rx_pb11>;
+	pinctrl-names = "default";
+	current-speed = <115200>;
+};
+
 &lpuart1 {
 	status = "okay";
 	zephyr,deferred-init;
@@ -377,7 +389,7 @@
 					<&gpioc 0 0>;
 
 		arduino,router-serial = <&lpuart1>; /* 'Serial' is provided by the Monitor */
-		serials = <&usart1>, <&lpuart1>;
+		serials = <&usart1>, <&lpuart1>, <&usart3>;
 		cans = <&fdcan1>;
 		i2cs = <&i2c2>, <&i2c4>, <&i2c3>;
 		spis = <&spi2>, <&spi3>;


### PR DESCRIPTION
Sometimes you need another Hardware Uart that is not also being used as the Zephyr Monitor.

So I created Serial3 using the hardware usart3 on the same pins as Wire (SCL, SDA).

I tried it with current sources including fix for the UNOQ double floating point issue.

**EDIT**: I was able to use those pins as either Wire object or as Serial3 object and test sketches worked.

Wishlist to investigate, it would be great to be able to add these types of alternate objects, however currently HardwareSerial objects come with a memory overhead as the buffers for the RX and TX queues are part of the main structure and as such allocated with the object was created.  Would be nice to have an alternative way to not have these as prt of the structure and only allocated if someone actually calls SerialX.begin(...)