### PR TITLE
variant: giga: set gt911 as deferred-init

### DIFF
--- a/variants/arduino_giga_r1_stm32h747xx_m7/arduino_giga_r1_stm32h747xx_m7.overlay
+++ b/variants/arduino_giga_r1_stm32h747xx_m7/arduino_giga_r1_stm32h747xx_m7.overlay
@@ -65,6 +65,10 @@
 	};
 };
 
+&gt911 {
+	zephyr,deferred-init;
+};
+
 &i2c1 {
 	status = "okay";
 	zephyr,deferred-init;


### PR DESCRIPTION
Mark the gt911 touch controller as `zephyr,deferred-init` since it depends on the deferred-initialized `i2c4` bus.