### PR TITLE
variant: portentac33: fix esp32 init

### DIFF
--- a/variants/arduino_portenta_c33_r7fa6m5bh3cfc/arduino_portenta_c33_r7fa6m5bh3cfc.overlay
+++ b/variants/arduino_portenta_c33_r7fa6m5bh3cfc/arduino_portenta_c33_r7fa6m5bh3cfc.overlay
@@ -91,9 +91,10 @@
 	/* usart9 is not set as deferred-init to catch early boot logs since it is assigned to zephyr,console */
 };
 
-&spi1 {
+/* spi1 currently not set to deferred-init to fix esp32 init */
+/* &spi1 {
 	zephyr,deferred-init;
-};
+}; */
 
 &sci3 {
 	status = "okay";


### PR DESCRIPTION
Set SPI1 to auto init to properly initialize the ESP32