### PR TITLE
ci: dependabot config: weekly check, one PR for everything

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "go"
+    directory: "tools/"
+    schedule:
+      interval: "weekly"
+    groups:
+      all-tools:
+        patterns:
+          - "*"


### PR DESCRIPTION
Set the configuration for dependabot to update the Go dependencies in the tools directory on a weekly basis as a single group.