### PR TITLE
nano33ble: fix upload addr

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -116,6 +116,7 @@ nano33ble.upload.interface=0
 nano33ble.upload.use_1200bps_touch=true
 nano33ble.upload.wait_for_upload_port=true
 nano33ble.upload.native_usb=true
+nano33ble.upload.offset=0x10000 # bootloader skips its own partition
 
 nano33ble.bootloader.tool=bossac
 nano33ble.bootloader.tool.default=bossac

--- a/extra/build.sh
+++ b/extra/build.sh
@@ -48,6 +48,7 @@ if ! [ -z "$chosen_board" ]; then
 	board=$(jq -cr '.board' <<< "$chosen_board")
 	target=$(jq -cr '.target' <<< "$chosen_board")
 	args=$(jq -cr '.args' <<< "$chosen_board")
+	upload_offset=$(jq -cr '.upload_offset' <<< "$chosen_board")
 
 	# Check for debug flag and append
 	if [ x$2 == x"--debug" ]; then
@@ -61,6 +62,7 @@ else
 	chosen_board=$(extra/get_board_details.sh | jq -cr ".[] | select(.target == \"$target\") // empty")
 	if [ ! -z "$chosen_board" ]; then
 		board=$(jq -cr '.board' <<< "$chosen_board")
+		upload_offset=$(jq -cr '.upload_offset' <<< "$chosen_board")
 	else
 		log_msg warning "No board for '$target' defined in 'boards.txt'. A proper definition is required to use the core."
 	fi
@@ -134,12 +136,23 @@ get_value_from_text_file() {
 
 update_local_field() {
 	local field=$1
-	local value=$2
+	local value="$2"
+	local comment="$3"
 	local full_field_name="${board}.${field}"
-	local match_regexp="^${full_field_name//./\\.}" # escape dots, match start of line
+	local match_regexp="${full_field_name//./\\.}" # escape dots
 
-	if grep -qE "${match_regexp}" boards.local.txt; then
-		sed -i -e "s/${match_regexp}=.*/${full_field_name}=${value}/" boards.local.txt
+	if [ -n "$comment" ]; then
+		# if there's a comment, add/update it as a commented-out line above the actual field
+		if grep -qE "^# ${match_regexp}:" boards.local.txt; then
+			sed -i -e "s/^# ${match_regexp}:.*/# ${full_field_name}: ${comment}/" boards.local.txt
+		else
+			echo "# ${full_field_name}: ${comment}" >> boards.local.txt
+		fi
+	fi
+
+	# update the actual field line
+	if grep -qE "^${match_regexp}" boards.local.txt; then
+		sed -i -e "s/^${match_regexp}=.*/${full_field_name}=${value}/" boards.local.txt
 	else
 		echo "${full_field_name}=${value}" >> boards.local.txt
 	fi
@@ -162,7 +175,14 @@ EOF
 
 	# sketch load address: start of sketch partition, hex (exact)
 	CODE_ADDR=$(get_value_from_text_file variants/${variant}/syms-static.ld '_sketch_start')
-	update_local_field "upload.address" $CODE_ADDR
+	if [ -z "$upload_offset" ] ; then
+		UPLOAD_ADDR=$CODE_ADDR
+		UPLOAD_ADDR_COMMENT=""
+	else
+		UPLOAD_ADDR=$(printf "0x%X" $((CODE_ADDR - upload_offset)))
+		UPLOAD_ADDR_COMMENT="$CODE_ADDR was offset by $upload_offset from ${board}.upload.offset"
+	fi
+	update_local_field "upload.address" "$UPLOAD_ADDR" "$UPLOAD_ADDR_COMMENT"
 
 	# maximum sketch size: size of sketch partition, decimal (exact limit)
 	CODE_SIZE=$(( $(get_value_from_text_file variants/${variant}/syms-static.ld '_sketch_max_size') ))

--- a/extra/get_board_details.sh
+++ b/extra/get_board_details.sh
@@ -6,13 +6,13 @@
 set -e
 
 get_boards() {
-	cat boards.txt | sed -e 's/#.*//' | grep -E '^.*\.build\.variant=' | sed -e 's/\.build\.variant=.*//'
+	cat boards.txt | sed -e 's/\s*#.*//' | grep -E '^.*\.build\.variant=' | sed -e 's/\.build\.variant=.*//'
 }
 
 get_board_field() {
 	board=$1
 	field=$2
-	cat boards.txt | sed -e 's/#.*//' | grep -E "^$board\\.$field=" | cut -d '=' -f2- | sed -e 's/"/\"/g'
+	cat boards.txt | sed -e 's/\s*#.*//' | grep -E "^$board\\.$field=" | cut -d '=' -f2- | sed -e 's/"/\"/g'
 }
 
 for BOARD in $(get_boards); do
@@ -23,6 +23,7 @@ for BOARD in $(get_boards); do
 	HALS=$(get_board_field $BOARD "build\\.zephyr_hals")
 	ARTIFACT=$(get_board_field $BOARD "build\\.artifact")
 	ARTIFACT=${ARTIFACT:-zephyr_contrib}
+	UPLOAD_OFFSET=$(get_board_field $BOARD "upload\\.offset")
 
 	ARTIFACT_JSON=extra/artifacts/$ARTIFACT.json
 	if ! [ -f "$ARTIFACT_JSON" ] ; then
@@ -49,7 +50,8 @@ for BOARD in $(get_boards); do
 	  "args": "$ARGS",
 	  "hals": "$HALS",
 	  "artifact": "$ARTIFACT",
-	  "subarch": "$SUBARCH"
+	  "subarch": "$SUBARCH",
+	  "upload_offset": "$UPLOAD_OFFSET"
 	}
 EOF
 done | jq -crs .


### PR DESCRIPTION
The Nano 33 BLE uses a bootloader which expects a quirky upload address value: the offset from the end of the bootloader partition. Add support for upload offsets and an exception for `nano33ble`.