### PR TITLE
openocd: use variants scripts to flash sketch and loader when needed

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -405,6 +405,7 @@ nicla_sense.build.zephyr_hals=hal_nordic
 nicla_sense.build.artifact=zephyr_main
 nicla_sense.build.variant=arduino_nicla_sense_me_nrf52832
 
+nicla_sense.openocd_cfg=flash_sketch.cfg
 nicla_sense.build.extra_flags=
 nicla_sense.build.postbuild.cmd="{tools.imgtool.path}/{tools.imgtool.cmd}" exit
 nicla_sense.build.board=NICLA_SENSE_ME
@@ -565,6 +566,7 @@ nano_matter.build.zephyr_hals=hal_silabs
 nano_matter.build.artifact=zephyr_main
 nano_matter.build.variant=arduino_nano_matter_mgm240sd22vna
 
+nano_matter.openocd_cfg=flash_sketch.cfg
 nano_matter.build.extra_flags=
 nano_matter.build.postbuild.cmd="{tools.imgtool.path}/{tools.imgtool.cmd}" exit
 nano_matter.build.board=ARDUINO_NANO_MATTER

--- a/platform.txt
+++ b/platform.txt
@@ -173,11 +173,11 @@ tools.openocd.cmd.windows=bin/openocd.exe
 
 tools.openocd.upload.params.verbose=-d2
 tools.openocd.upload.params.quiet=-d0
-tools.openocd.upload.pattern="{path}/{cmd}" {upload.verbose} -s "{path}/share/openocd/scripts/" {upload.programmer} {upload.config} -c "telnet_port disabled; init; reset init; halt; adapter speed 10000; flash write_image erase {{build.path}/{build.project_name}.{upload.extension}} {upload.address} bin; reset run; shutdown"
+tools.openocd.upload.pattern="{path}/{cmd}" -s "{path}/share/openocd/scripts/" {upload.programmer} {upload.config} -c "set filename0 "{runtime.platform.path}/firmwares/{bootloader.file}"" -c "set filename1 "{build.path}/{build.project_name}.{upload.extension}"" -c "set offset {upload.address}" -f "{build.variant.path}/{openocd_cfg}" "{upload.verbose}"
 
 tools.openocd.program.params.verbose=-d2
 tools.openocd.program.params.quiet=-d0
-tools.openocd.program.pattern="{path}/{cmd}" {program.verbose} -s "{path}/share/openocd/scripts/" {upload.programmer} {upload.config} -c "telnet_port disabled; init; reset init; halt; adapter speed 10000; flash write_image erase {{build.path}/{build.project_name}.{upload.extension}} {upload.address} bin; reset run; shutdown"
+tools.openocd.upload.pattern="{path}/{cmd}" -s "{path}/share/openocd/scripts/" {upload.programmer} {upload.config} -c "set filename0 "{runtime.platform.path}/firmwares/{bootloader.file}"" -c "set filename1 "{build.path}/{build.project_name}.{upload.extension}"" -c "set offset {upload.address}" -f "{build.variant.path}/{openocd_cfg}" "{upload.verbose}"
 
 tools.openocd.erase.params.verbose=-d2
 tools.openocd.erase.params.quiet=-d0
@@ -185,7 +185,7 @@ tools.openocd.erase.pattern=
 
 tools.openocd.bootloader.params.verbose=-d2
 tools.openocd.bootloader.params.quiet=-d0
-tools.openocd.bootloader.pattern="{path}/{cmd}" {bootloader.verbose} -s "{path}/share/openocd/scripts/" {upload.programmer} {upload.config} -c "telnet_port disabled; init; reset init; halt; adapter speed 10000; program {{runtime.platform.path}/firmwares/{bootloader.file}}; reset run; shutdown"
+tools.openocd.bootloader.pattern="{path}/{cmd}" -s "{path}/share/openocd/scripts/" {upload.programmer} {upload.config} -c "set filename0 "{runtime.platform.path}/firmwares/{bootloader.file}"" -f "{build.variant.path}/flash_bootloader.cfg" "{upload.verbose}"
 
 #
 # BOSSA

--- a/variants/arduino_nano_matter_mgm240sd22vna/flash_bootloader.cfg
+++ b/variants/arduino_nano_matter_mgm240sd22vna/flash_bootloader.cfg
@@ -1,0 +1,13 @@
+# Copyright (c) Arduino s.r.l. and/or its affiliated companies
+# SPDX-License-Identifier: Apache-2.0
+
+telnet_port disabled
+init
+reset init
+halt
+adapter speed 10000
+if {[catch {flash verify_image ${filename0}}] != 0} {
+	flash write_image erase ${filename0}
+}
+reset run
+shutdown

--- a/variants/arduino_nano_matter_mgm240sd22vna/flash_sketch.cfg
+++ b/variants/arduino_nano_matter_mgm240sd22vna/flash_sketch.cfg
@@ -1,0 +1,17 @@
+# Copyright (c) Arduino s.r.l. and/or its affiliated companies
+# SPDX-License-Identifier: Apache-2.0
+
+telnet_port disabled
+init
+reset init
+halt
+adapter speed 10000
+#flash write_image erase ${filename1} ${offset} bin
+if {[catch {flash verify_image ${filename0}}] != 0} {
+	flash write_image erase ${filename0}
+}
+if {[catch {flash verify_image ${filename1} ${offset} bin}] != 0} {
+	flash write_image erase ${filename1} ${offset} bin
+}
+reset run
+shutdown

--- a/variants/arduino_nicla_sense_me_nrf52832/flash_bootloader.cfg
+++ b/variants/arduino_nicla_sense_me_nrf52832/flash_bootloader.cfg
@@ -1,0 +1,13 @@
+# Copyright (c) Arduino s.r.l. and/or its affiliated companies
+# SPDX-License-Identifier: Apache-2.0
+
+telnet_port disabled
+init
+reset init
+halt
+adapter speed 10000
+if {[catch {flash verify_image ${filename0}}] != 0} {
+	flash write_image erase ${filename0}
+}
+reset run
+shutdown

--- a/variants/arduino_nicla_sense_me_nrf52832/flash_sketch.cfg
+++ b/variants/arduino_nicla_sense_me_nrf52832/flash_sketch.cfg
@@ -1,0 +1,17 @@
+# Copyright (c) Arduino s.r.l. and/or its affiliated companies
+# SPDX-License-Identifier: Apache-2.0
+
+telnet_port disabled
+init
+reset init
+halt
+adapter speed 10000
+#flash write_image erase ${filename1} ${offset} bin
+if {[catch {flash verify_image ${filename0}}] != 0} {
+	flash write_image erase ${filename0}
+}
+if {[catch {flash verify_image ${filename1} ${offset} bin}] != 0} {
+	flash write_image erase ${filename1} ${offset} bin
+}
+reset run
+shutdown


### PR DESCRIPTION
Keep loader in sync with sketch on `nano_matter` and `nicla_sense`

I don't think `openocd_cfg` is strictly necessary, as it could be hardcoded in `platform.txt` just like the loader script. However, I've included it here to maintain consistency with `unoq`.