### PR TITLE
stm32h7: increase user sketch partition to fill available Flash

### DIFF
--- a/variants/arduino_giga_r1_stm32h747xx_m7/arduino_giga_r1_stm32h747xx_m7.overlay
+++ b/variants/arduino_giga_r1_stm32h747xx_m7/arduino_giga_r1_stm32h747xx_m7.overlay
@@ -408,17 +408,18 @@
 };
 
 
-/delete-node/ &slot0_partition;
-
 &flash0 {
+	reg = <0x8000000 DT_SIZE_K(2048)>;     /* assign all Flash to the M7 */
+	status = "okay";
+
 	partitions {
 		slot0_partition: partition@40000 {
 			label = "image-0";
-			reg = <0x040000 0xa0000>;
+			reg = <0x00040000 0x000A0000>;
 		};
 
 		user_sketch: partition@e0000 {
-			reg = <0x000E0000 0x00040000>;
+			reg = <0x000E0000 0x00120000>;
 		};
 	};
 };

--- a/variants/arduino_nicla_vision_stm32h747xx_m7/arduino_nicla_vision_stm32h747xx_m7.overlay
+++ b/variants/arduino_nicla_vision_stm32h747xx_m7/arduino_nicla_vision_stm32h747xx_m7.overlay
@@ -194,51 +194,29 @@
 };
 
 /*
- * Flash Partition Layout Override
  * Custom partition layout for Arduino Core compatibility:
  * - mcuboot: 256KB bootloader
  * - image-0: 640KB loader slot
- * - user_sketch: 128KB user data
- * Total: 1MB internal flash
+ * - user_sketch: rest of Flash
  */
+
+&flash0 {
+	reg = <0x8000000 DT_SIZE_K(2048)>;     /* assign all Flash to the M7 */
+	status = "okay";
+
+	partitions {
+		slot0_partition: partition@40000 {
+			label = "image-0";
+			reg = <0x00040000 0x000A0000>;
+		};
+
+		user_sketch: partition@e0000 {
+			reg = <0x000E0000 0x00120000>;
+		};
+	};
+};
+
 / {
-    soc {
-        flash-controller@52002000 {
-            flash0: flash@8000000 {
-                /delete-node/ partitions;
-                compatible = "st,stm32-nv-flash", "soc-nv-flash";
-                write-block-size = <32>;
-                erase-block-size = <DT_SIZE_K(128)>;
-                /* maximum erase time for a 128K sector */
-                max-erase-time = <4000>;
-
-                reg = <0x08000000 DT_SIZE_K(1024)>;
-                status = "okay";
-
-                partitions {
-                    compatible = "fixed-partitions";
-                    #address-cells = <1>;
-                    #size-cells = <1>;
-
-                    boot_partition: partition@0 {
-                            label = "mcuboot";
-                            reg = <0x00000000 0x00040000>;
-                            read-only;
-                    };
-
-                    slot0_partition: partition@40000 {
-                            label = "image-0";
-                            reg = <0x00040000 0x000A0000>;
-                    };
-
-                    user_sketch: partition@e0000 {
-                        reg = <0x000E0000 0x00040000>;
-                    };
-                };
-            };
-        };
-    };
-
     zephyr,user {
         digital-pin-gpios = <&gpiog 12 GPIO_ACTIVE_HIGH>,   /* D0  PG12 */
                             <&gpioa 9 GPIO_ACTIVE_HIGH>,    /* D1  PA9  */

--- a/variants/arduino_opta_stm32h747xx_m7/arduino_opta_stm32h747xx_m7.overlay
+++ b/variants/arduino_opta_stm32h747xx_m7/arduino_opta_stm32h747xx_m7.overlay
@@ -72,9 +72,17 @@
 };
 
 &flash0 {
+	reg = <0x8000000 DT_SIZE_K(2048)>;     /* assign all Flash to the M7 */
+	status = "okay";
+
 	partitions {
+		slot0_partition: partition@40000 {
+			label = "image-0";
+			reg = <0x00040000 0x000A0000>;
+		};
+
 		user_sketch: partition@e0000 {
-			reg = <0x000E0000 0x00040000>;
+			reg = <0x000E0000 0x00120000>;
 		};
 	};
 };

--- a/variants/arduino_portenta_h7_stm32h747xx_m7/arduino_portenta_h7_stm32h747xx_m7.overlay
+++ b/variants/arduino_portenta_h7_stm32h747xx_m7/arduino_portenta_h7_stm32h747xx_m7.overlay
@@ -318,41 +318,29 @@
 	};
 };
 
-/ {
-	soc {
-		flash-controller@52002000 {
-			flash0: flash@8000000 {
-				/delete-node/ partitions;
-				compatible = "st,stm32-nv-flash", "soc-nv-flash";
-				write-block-size = <32>;
-				erase-block-size = <DT_SIZE_K(128)>;
-				/* maximum erase time for a 128K sector */
-				max-erase-time = <4000>;
+&flash0 {
+	reg = <0x8000000 DT_SIZE_K(2048)>;     /* assign all Flash to the M7 */
+	status = "okay";
 
-				reg = <0x08000000 DT_SIZE_K(1024)>;
-				status = "okay";
+	/delete-node/ partitions;
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
 
-				partitions {
-					compatible = "fixed-partitions";
-					#address-cells = <1>;
-					#size-cells = <1>;
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x00000000 0x00040000>;
+			read-only;
+		};
 
-					boot_partition: partition@0 {
-						label = "mcuboot";
-						reg = <0x00000000 0x00040000>;
-						read-only;
-					};
+		slot0_partition: partition@40000 {
+			label = "image-0";
+			reg = <0x00040000 0x000A0000>;
+		};
 
-					slot0_partition: partition@40000 {
-						label = "image-0";
-						reg = <0x00040000 0x000A0000>;
-					};
-
-					user_sketch: partition@e0000 {
-						reg = <0x000E0000 0x00040000>;
-					};
-				};
-			};
+		user_sketch: partition@e0000 {
+			reg = <0x000E0000 0x00120000>;
 		};
 	};
 };


### PR DESCRIPTION
Assign all Flash to the M7 core and increase the user sketch partition to fill the available Flash, allowing larger sketches and LVGL examples to be built and run on the M7 core.

Fixes several errors in the partition tables:
- all H7 partition tables overflowed the controller space
- opta had slot0 overlapping with user_sketch