### PR TITLE
ci: nano33ble: Add sensor libraries

### DIFF
--- a/variants/arduino_nano_33_ble_nrf52840_sense/test_setup.sh
+++ b/variants/arduino_nano_33_ble_nrf52840_sense/test_setup.sh
@@ -11,6 +11,19 @@
 # (the repos must have been downloaded by ci_fetch_tests.sh first).
 # skip_for_this_board removes all tests under the given path prefix.
 
+# Board-specific external repos
+get_branch_tip libraries arduino-libraries/Arduino_BMI270_BMM150 master \
+	examples/SimpleAccelerometer \
+
+get_branch_tip libraries arduino-libraries/Arduino_APDS9960 master \
+	examples/ColorSensor \
+
+get_branch_tip libraries arduino-libraries/Arduino_LPS22HB master \
+	examples/ReadPressure \
+
+get_branch_tip libraries arduino-libraries/Arduino_HS300x master \
+	examples/ReadSensors \
+
 skip_for_this_board libraries/Arduino_SecureElement
 skip_for_this_board libraries/Camera
 skip_for_this_board libraries/Ethernet


### PR DESCRIPTION
This pull request increases the continuous integration (CI) test coverage for the `nano33ble` board target by adding the necessary libraries supporting its built-in sensors.