### PR TITLE
WiFi: airoc firmware loading and troubleshooting

### DIFF
--- a/.github/workflows/format_check.yml
+++ b/.github/workflows/format_check.yml
@@ -39,6 +39,7 @@ jobs:
             libraries/examples/**
             libraries/extras/**
             libraries/ea_malloc/**
+            libraries/Storage/examples/FlashFormat/4343WA1_bin.h
           json: true
       - name: Export changed files in a text file, one per line
         if: steps.changed-files.outputs.any_changed == 'true'

--- a/README.md
+++ b/README.md
@@ -78,6 +78,11 @@ To get started with your board:
 **A:** If you have installed the core locally in your Arduino sketchbook, make sure the Zephyr core is installed in a folder named `zephyr` (`${sketchbook}/hardware/arduino-git/zephyr`).
 See the [Using the Core in Arduino IDE/CLI](#using-the-core-in-arduino-idecli) section for further details on the installation.
 
+---
+
+#### **Q: Wi-Fi is not working, or I get `Communication with WiFi module failed!` in the Serial Monitor**
+**A:** You are probably missing the Wi-Fi firmware, or the firmware is corrupted. Boards should come with the Wi-Fi firmware already flashed, but in case Wi-Fi is not working run the [`FlashFormat`](libraries/Storage/examples/FlashFormat/FlashFormat.ino) sketch to restore the firmware.
+
 ## 📚 Libraries
 
 ### Included with the core: ###

--- a/libraries/Storage/examples/FlashFormat/4343WA1_bin.h
+++ b/libraries/Storage/examples/FlashFormat/4343WA1_bin.h
@@ -1,0 +1,1 @@
+../../../../loader/blobs/4343WA1_bin.c

--- a/libraries/Storage/examples/FlashFormat/FlashFormat.ino
+++ b/libraries/Storage/examples/FlashFormat/FlashFormat.ino
@@ -16,6 +16,10 @@
 #include <zephyr/storage/flash_map.h>
 #include "certificates.h"
 
+#if defined(CONFIG_AIROC_WIFI_CUSTOM)
+#include "4343WA1_bin.h"
+#endif
+
 // MBR structures
 struct __attribute__((packed)) mbrEntry {
     uint8_t status;
@@ -117,6 +121,44 @@ int flashCertificates() {
     Serial.println("Certificates written successfully!");
     return 0;
 }
+
+#if defined(CONFIG_AIROC_WIFI_CUSTOM)
+int flashWiFiFirmware() {
+    Serial.print("WiFi firmware size: ");
+    Serial.print(sizeof(wifi_firmware_image_data));
+    Serial.println(" bytes");
+
+    const struct flash_area *fa;
+    int ret = flash_area_open(FIXED_PARTITION_ID(airoc_firmware), &fa);
+    if (ret) {
+        Serial.print("Error opening airoc_firmware partition: ");
+        Serial.println(ret);
+        return ret;
+    }
+
+    Serial.println("Erasing WiFi firmware partition...");
+    ret = flash_area_erase(fa, 0, fa->fa_size);
+    if (ret) {
+        Serial.print("Error erasing airoc_firmware partition: ");
+        Serial.println(ret);
+        flash_area_close(fa);
+        return ret;
+    }
+
+    Serial.println("Writing WiFi firmware...");
+    ret = flash_area_write(fa, 0, wifi_firmware_image_data, sizeof(wifi_firmware_image_data));
+    if (ret) {
+        Serial.print("Error writing WiFi firmware: ");
+        Serial.println(ret);
+        flash_area_close(fa);
+        return ret;
+    }
+
+    flash_area_close(fa);
+    Serial.println("WiFi firmware written successfully!");
+    return 0;
+}
+#endif
 
 int flashMBR() {
     Serial.println("Creating MBR partition table...");
@@ -279,6 +321,14 @@ void setup() {
             Serial.println("Please use LittleFS or update device tree configuration.");
         }
     }
+
+    // Memory Mapped Wi-Fi firmware
+#if defined(CONFIG_AIROC_WIFI_CUSTOM)
+    Serial.println("\nDo you want to restore the WiFi firmware? Y/[n]");
+    if (waitResponse() && flashWiFiFirmware()) {
+        return;
+    }
+#endif
 
     Serial.println("\nFlash storage formatted!");
     Serial.println("It's now safe to reboot or disconnect your board.");

--- a/loader/blobs/4343WA1_bin.c
+++ b/loader/blobs/4343WA1_bin.c
@@ -25480,5 +25480,5 @@ const unsigned char wifi_firmware_image_data[421098] = {
         49, 45, 53, 97, 102, 99, 56, 99, 49, 101, 0, 254, 0, 68, 86, 73, 68,
         32, 48, 49, 45, 101, 100, 48, 100, 55, 97, 53, 54
 };
-resource_hnd_t wifi_firmware_image = { RESOURCE_IN_MEMORY, 421098, {.mem = { wifi_firmware_image_data }}};
+resource_hnd_t wifi_firmware_image = { RESOURCE_IN_MEMORY, 421098, {.mem = { (const char *)wifi_firmware_image_data }}};
 


### PR DESCRIPTION
Add a simple way for users to flash airoc Wi-Fi firmware using a sketch. The firmware is used in the following boards:
 - GIGA R1
 - Portenta H7
 - OPTA
 - Nicla Vision 