### PR TITLE
ci: use latest ci-builds JSON as a reference

### DIFF
--- a/.github/workflows/package_core.yml
+++ b/.github/workflows/package_core.yml
@@ -325,22 +325,112 @@ jobs:
           ./extra/package_core.sh ${{ matrix.artifact }} ${CORE_TAG} distrib/${CORE_ARTIFACT}
 
       - uses: actions/upload-artifact@v7
+        id: upload-core
         if: ${{ success() || failure() }}
         with:
           name: ${{ env.CORE_ARTIFACT }}
           path: distrib/${{ env.CORE_ARTIFACT }}
           archive: false
 
+      - name: Archive artifact ID
+        run: |
+          echo '${{ steps.upload-core.outputs.artifact-id }}' > ${{ matrix.artifact }}.id
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: artifact-id-${{ matrix.artifact }}
+          path: ${{ matrix.artifact }}.id
 
 
-  # After generating the final cores, the API and per-board binary archives are no longer needed.
-  # The build environment archive can also be removed.
+
+  # Prepare this PR's temporary package index JSON by merging the newly
+  # built core packages with the latest package index from ci-builds.
+
+  package-index:
+    name: Prepare temp package index JSON
+    runs-on: ubuntu-latest
+    needs:
+      - build-env
+      - package-core
+    if: ${{ github.event_name == 'pull_request' && needs.build-env.outputs.CI_BUILDS_URL != '' }}
+    env:
+      CORE_HASH: ${{ needs.build-env.outputs.CORE_HASH }}
+      CORE_BRANCH: ${{ needs.build-env.outputs.CORE_BRANCH }}
+      ARTIFACTS: ${{ needs.build-env.outputs.ARTIFACTS }}
+      CI_BUILDS_URL: ${{ needs.build-env.outputs.CI_BUILDS_URL }}
+    steps:
+
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          fetch-tags: true
+
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: ArduinoCore-*.tar.bz2
+          path: .
+          merge-multiple: true
+
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: artifact-id-*
+          path: .
+          merge-multiple: true
+
+      - name: Prepare PR package index
+        run: |
+          wget ${CI_BUILDS_URL} -O ci_index.json
+          # clear other platforms from the index
+          jq '.packages[0].platforms = []' ci_index.json > ci_index.tmp && mv ci_index.tmp ci_index.json
+
+          mkdir -p snippets/platforms/
+          jq -cr '.[]' <<< ${ARTIFACTS} | while read -r artifact; do
+            [ $artifact == "zephyr" ] && continue
+            ARTIFACT_FILE=ArduinoCore-${artifact}-${CORE_HASH}.tar.bz2
+            PACKAGE_JSON=snippets/platforms/${artifact}.json
+            ./extra/gen_package_index_json.sh ${artifact} ${ARTIFACT_FILE} ${PACKAGE_JSON}
+            # replace the download URL with this PR's artifact link
+            ARTIFACT_ID=$(cat ${artifact}.id)
+            ARTIFACT_URL="https://api.github.com/repos/${{ github.repository }}/actions/artifacts/${ARTIFACT_ID}/zip"
+            sed -i -e "s!\"url\":.*!\"url\": \"${ARTIFACT_URL}\",!" ${PACKAGE_JSON}
+            # append the new snippet to the index
+            jq -s '.[0].packages[0].platforms += .[1].packages[0].platforms | .[0]' \
+                    ci_index.json ${PACKAGE_JSON} > ci_index.tmp && mv ci_index.tmp ci_index.json
+          done
+          PACKAGE_INDEX_FILE="package_arduino_zephyr_pr_${{ github.event.pull_request.number }}_ci_index.json"
+          echo "PACKAGE_INDEX_FILE=${PACKAGE_INDEX_FILE}" >> $GITHUB_ENV
+          mv ci_index.json ${PACKAGE_INDEX_FILE}
+
+      - name: Archive PR package index
+        id: package-index-json
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ env.PACKAGE_INDEX_FILE }}
+          path: ${{ env.PACKAGE_INDEX_FILE }}
+          archive: false
+
+      - run: |
+          ARTIFACT_ID=${{ steps.package-index-json.outputs.artifact-id }}
+          PACKAGE_INDEX_URL="https://api.github.com/repos/${{ github.repository }}/actions/artifacts/${ARTIFACT_ID}/zip"
+          PACKAGE_INDEX_URL="${PACKAGE_INDEX_URL}#${{ env.PACKAGE_INDEX_FILE }}"
+          echo "::notice title=Package index URL for offline tests::${PACKAGE_INDEX_URL}"
+
+
+
+  # After generating the final cores, the following temporary artifacts are
+  # no longer used and can be removed:
+  #
+  #  - the Zephyr build environment
+  #  - the API and per-board binaries
+  #  - the artifact download URLs
 
   cleanup-build:
     name: Clean up intermediates
     runs-on: ubuntu-latest
     needs:
       - package-core
+      - package-index
     steps:
 
       - uses: geekyeggo/delete-artifact@v6
@@ -349,6 +439,7 @@ jobs:
             arduino-api.tar.zstd
             binaries-*
             build-env.tar.zstd
+            artifact-id-*
           failOnError: false
 
 
@@ -627,6 +718,8 @@ jobs:
           done
           aws s3 cp size-reports-*.tar.bz2 s3://${{ secrets.S3_BUCKET }}/size-reports/
 
+
+
   # Prepare the package index JSON snippets for the newly built core packages.
 
   prepare-json:
@@ -675,6 +768,12 @@ jobs:
         with:
           name: snippets-${{ env.CORE_TAG }}
           path: snippets/
+
+
+
+  # Upload the newly built core packages and package index snippets to the
+  # ci-builds repository so the build is fully logged and the next PRs can
+  # use them as a reference for testing.
 
   ci-builds-upload:
     name: Upload to ci-builds

--- a/.github/workflows/package_core.yml
+++ b/.github/workflows/package_core.yml
@@ -69,10 +69,8 @@ jobs:
           persist-credentials: false
           fetch-tags: true # needed for get_core_version.sh
 
-      - name: Initialize Zephyr environment
+      - name: Identify current version and board set
         run: |
-          # Install Zephyr as a core user would, but faster
-          yes | ./extra/bootstrap.sh -o=--filter=tree:0
           # Set up basic environment for later steps
           echo "CORE_HASH=$(git describe --always $HEAD_REF)" >> "$GITHUB_ENV"
           echo "ALL_BOARD_DATA=$(extra/get_board_details.sh | jq -c 'sort_by(.variant)')" >> "$GITHUB_ENV"
@@ -93,6 +91,11 @@ jobs:
           echo "ALL_BOARD_FQBNS=$(jq -c 'map((. + {link_mode: "static"}), (. + {link_mode: "dynamic"}))' <<< ${ALL_BOARD_DATA})" >> "$GITHUB_ENV"
           echo "ARTIFACTS=$(jq -c '["zephyr"] + (map(.artifact) | unique)' <<< ${ALL_BOARD_DATA})" >> "$GITHUB_ENV"
           echo "SUB_ARCHES=$(jq -c 'map(.subarch) | unique' <<< ${ALL_BOARD_DATA})" >> "$GITHUB_ENV"
+
+      - name: Initialize Zephyr environment
+        run: |
+          # Install Zephyr as a core user would, but faster
+          yes | ./extra/bootstrap.sh -o=--filter=tree:0
           # Archive the build environment for later jobs
           (cd && tar cphf - .cmake work zephyr-sdk-* | zstd > build-env.tar.zstd)
           # The API is only needed for packaging, not for building, so it's separate

--- a/.github/workflows/package_core.yml
+++ b/.github/workflows/package_core.yml
@@ -88,7 +88,7 @@ jobs:
             [[ -n "$BRANCH" ]] || { echo "::error::No branch found containing tag ${{ github.ref_name }}"; exit 1; }
             echo "CORE_BRANCH=${BRANCH}" >> "$GITHUB_ENV"
           else
-            echo "CORE_BRANCH=${{ github.head_ref || github.ref_name }}" >> "$GITHUB_ENV"
+            echo "CORE_BRANCH=${{ github.base_ref || github.ref_name }}" >> "$GITHUB_ENV"
           fi
           echo "ALL_BOARD_FQBNS=$(jq -c 'map((. + {link_mode: "static"}), (. + {link_mode: "dynamic"}))' <<< ${ALL_BOARD_DATA})" >> "$GITHUB_ENV"
           echo "ARTIFACTS=$(jq -c '["zephyr"] + (map(.artifact) | unique)' <<< ${ALL_BOARD_DATA})" >> "$GITHUB_ENV"

--- a/.github/workflows/package_core.yml
+++ b/.github/workflows/package_core.yml
@@ -53,6 +53,8 @@ jobs:
       ARTIFACTS: ${{ env.ARTIFACTS }}
       # List of architectures the artifacts will be built for
       SUB_ARCHES: ${{ env.SUB_ARCHES }}
+      # URL of the latest ci-builds index for this branch, if any
+      CI_BUILDS_URL: ${{ env.CI_BUILDS_URL }}
     steps:
 
       - name: Install OS dependencies
@@ -100,6 +102,25 @@ jobs:
           (cd && tar cphf - .cmake work zephyr-sdk-* | zstd > build-env.tar.zstd)
           # The API is only needed for packaging, not for building, so it's separate
           tar cphf - cores/arduino/api | zstd > arduino-api.tar.zstd
+
+      - name: Get ci-builds package index link
+        if: ${{ github.repository == 'arduino/ArduinoCore-zephyr' }}
+        run: |
+          # for pull requests and pushes to the official Arduino repo, use the latest ci-built core as a reference
+          CI_BUILDS_URL="https://arduino.github.io/core-ci-builds/package_arduino_zephyr_${CORE_BRANCH}_ci_index.json"
+          if ! wget -q --method=HEAD "$CI_BUILDS_URL" >& /dev/null ; then
+            CLOSEST_BRANCH=$(git branch -r | grep -vE "HEAD|/$(git branch --show-current)$" | while read -r b; do \
+                               echo "$(git rev-list --count $b..HEAD) $b" ; \
+                             done | sort -n | head -n 1 | awk '{print $2}' | cut -d / -f 2)
+            [ -z "$CLOSEST_BRANCH" ] && CLOSEST_BRANCH="main"
+            echo "::warning::No ci-builds index found for branch $CORE_BRANCH, using $CLOSEST_BRANCH"
+            CI_BUILDS_URL="https://arduino.github.io/core-ci-builds/package_arduino_zephyr_${CLOSEST_BRANCH}_ci_index.json"
+            if ! wget -q --method=HEAD "$CI_BUILDS_URL" >& /dev/null ; then
+              echo "::warning::No ci-builds index found for branch $CLOSEST_BRANCH, using main"
+              CI_BUILDS_URL="https://arduino.github.io/core-ci-builds/package_arduino_zephyr_main_ci_index.json"
+            fi
+          fi
+          echo "CI_BUILDS_URL=$CI_BUILDS_URL" >> "$GITHUB_ENV"
 
       - name: Download test data
         run: |
@@ -353,6 +374,7 @@ jobs:
       FQBN: arduino:${{ matrix.subarch }}:${{ matrix.board }}:link_mode=${{ matrix.link_mode }}
       CORE_ARTIFACT: ArduinoCore-${{ matrix.artifact }}-${{ needs.build-env.outputs.CORE_HASH }}.tar.bz2
       ARTIFACT_TAG: ${{ needs.build-env.outputs.CORE_HASH }}-${{ matrix.board }}-${{ matrix.link_mode }}
+      CI_BUILDS_URL: ${{ needs.build-env.outputs.CI_BUILDS_URL }}
     if: ${{ !cancelled() && needs.build-env.result == 'success' }}
     steps:
 
@@ -389,7 +411,8 @@ jobs:
       - name: Compile tests for ${{ matrix.board }}
         uses: pillo79/compile-sketches@next
         with:
-          fqbn: ${{ env.FQBN }}
+          # Use ci-builds core, if possible, to use the exact set of tools required by the source
+          fqbn: ${{ env.FQBN }} ${{ env.CI_BUILDS_URL }}
           platforms: |
             # Use Board Manager version first to install the tools
             - name: ${{ env.PLAT }}

--- a/.github/workflows/package_core.yml
+++ b/.github/workflows/package_core.yml
@@ -325,22 +325,113 @@ jobs:
           ./extra/package_core.sh ${{ matrix.artifact }} ${CORE_TAG} distrib/${CORE_ARTIFACT}
 
       - uses: actions/upload-artifact@v7
+        id: upload-core
         if: ${{ success() || failure() }}
         with:
           name: ${{ env.CORE_ARTIFACT }}
           path: distrib/${{ env.CORE_ARTIFACT }}
           archive: false
 
+      - name: Archive artifact ID
+        run: |
+          echo '${{ steps.upload-core.outputs.artifact-id }}' > ${{ matrix.artifact }}.id
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: artifact-id-${{ matrix.artifact }}
+          path: ${{ matrix.artifact }}.id
 
 
-  # After generating the final cores, the API and per-board binary archives are no longer needed.
-  # The build environment archive can also be removed.
+
+  # Prepare this PR's temporary package index JSON by merging the newly
+  # built core packages with the latest package index from ci-builds.
+
+  package-index:
+    name: Package index URL for offline tests
+    runs-on: ubuntu-latest
+    needs:
+      - build-env
+      - package-core
+    if: ${{ github.event_name == 'pull_request' && needs.build-env.outputs.CI_BUILDS_URL != '' }}
+    env:
+      CORE_HASH: ${{ needs.build-env.outputs.CORE_HASH }}
+      CORE_BRANCH: ${{ needs.build-env.outputs.CORE_BRANCH }}
+      ARTIFACTS: ${{ needs.build-env.outputs.ARTIFACTS }}
+      CI_BUILDS_URL: ${{ needs.build-env.outputs.CI_BUILDS_URL }}
+    steps:
+
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          fetch-tags: true
+
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: ArduinoCore-*.tar.bz2
+          path: .
+          merge-multiple: true
+
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: artifact-id-*
+          path: .
+          merge-multiple: true
+
+      - name: Prepare PR package index
+        run: |
+          wget ${CI_BUILDS_URL} -O ci_index.json
+          # clear other platforms from the index
+          jq '.packages[0].platforms = []' ci_index.json > ci_index.tmp && mv ci_index.tmp ci_index.json
+
+          mkdir -p snippets/platforms/
+          jq -cr '.[]' <<< ${ARTIFACTS} | while read -r artifact; do
+            [ $artifact == "zephyr" ] && continue
+            ARTIFACT_FILE=ArduinoCore-${artifact}-${CORE_HASH}.tar.bz2
+            PACKAGE_JSON=snippets/platforms/${artifact}.json
+            ./extra/gen_package_index_json.sh ${artifact} ${ARTIFACT_FILE} ${PACKAGE_JSON}
+            # replace the download URL with this PR's artifact link
+            ARTIFACT_ID=$(cat ${artifact}.id)
+            ARTIFACT_URL="https://api.github.com/repos/${{ github.repository }}/actions/artifacts/${ARTIFACT_ID}/zip"
+            sed -i -e "s!\"url\":.*!\"url\": \"${ARTIFACT_URL}\",!" ${PACKAGE_JSON}
+            # append the new snippet to the index
+            jq -s '.[0].packages[0].platforms += .[1].packages[0].platforms | .[0]' \
+                    ci_index.json ${PACKAGE_JSON} > ci_index.tmp && mv ci_index.tmp ci_index.json
+          done
+          PACKAGE_INDEX_FILE="package_arduino_zephyr_pr_${{ github.event.pull_request.number }}_ci_index.json"
+          echo "PACKAGE_INDEX_FILE=${PACKAGE_INDEX_FILE}" >> $GITHUB_ENV
+          mv ci_index.json ${PACKAGE_INDEX_FILE}
+
+      - name: Archive PR package index
+        id: package-index-json
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ env.PACKAGE_INDEX_FILE }}
+          path: ${{ env.PACKAGE_INDEX_FILE }}
+          archive: false
+
+      - name: Display final URL in the summary
+        run: |
+          ARTIFACT_ID=${{ steps.package-index-json.outputs.artifact-id }}
+          PACKAGE_INDEX_URL="https://api.github.com/repos/${{ github.repository }}/actions/artifacts/${ARTIFACT_ID}/zip"
+          PACKAGE_INDEX_URL="${PACKAGE_INDEX_URL}#${{ env.PACKAGE_INDEX_FILE }}"
+          echo "[${PACKAGE_INDEX_URL}](${PACKAGE_INDEX_URL})" >> $GITHUB_STEP_SUMMARY
+
+
+
+  # After generating the final cores, the following temporary artifacts are
+  # no longer used and can be removed:
+  #
+  #  - the Zephyr build environment
+  #  - the API and per-board binaries
+  #  - the artifact download URLs
 
   cleanup-build:
     name: Clean up intermediates
     runs-on: ubuntu-latest
     needs:
       - package-core
+      - package-index
     steps:
 
       - uses: geekyeggo/delete-artifact@v6
@@ -349,6 +440,7 @@ jobs:
             arduino-api.tar.zstd
             binaries-*
             build-env.tar.zstd
+            artifact-id-*
           failOnError: false
 
 
@@ -627,6 +719,8 @@ jobs:
           done
           aws s3 cp size-reports-*.tar.bz2 s3://${{ secrets.S3_BUCKET }}/size-reports/
 
+
+
   # Prepare the package index JSON snippets for the newly built core packages.
 
   prepare-json:
@@ -675,6 +769,12 @@ jobs:
         with:
           name: snippets-${{ env.CORE_TAG }}
           path: snippets/
+
+
+
+  # Upload the newly built core packages and package index snippets to the
+  # ci-builds repository so the build is fully logged and the next PRs can
+  # use them as a reference for testing.
 
   ci-builds-upload:
     name: Upload to ci-builds

--- a/.github/workflows/package_core.yml
+++ b/.github/workflows/package_core.yml
@@ -59,6 +59,7 @@ jobs:
 
       - name: Install OS dependencies
         working-directory: /opt
+        timeout-minutes: 2 # early error on Github network issues
         run: |
           sudo apt-get remove --purge man-db -y # skips the mandb triggers
           sudo apt-get update
@@ -95,6 +96,7 @@ jobs:
           echo "SUB_ARCHES=$(jq -c 'map(.subarch) | unique' <<< ${ALL_BOARD_DATA})" >> "$GITHUB_ENV"
 
       - name: Initialize Zephyr environment
+        timeout-minutes: 5 # early error on Github network issues
         run: |
           # Install Zephyr as a core user would, but faster
           yes | ./extra/bootstrap.sh -o=--filter=tree:0
@@ -176,11 +178,13 @@ jobs:
     steps:
 
       - uses: actions/download-artifact@v8
+        timeout-minutes: 5 # early error on Github network issues
         with:
           path: /home/runner
           name: build-env.tar.zstd
 
       - name: Restore build environment
+        timeout-minutes: 2 # early error on Github network issues
         run: |
           sudo apt-get remove --purge man-db -y # skips the mandb triggers
           sudo apt-get update

--- a/extra/get_core_version.sh
+++ b/extra/get_core_version.sh
@@ -15,7 +15,7 @@
 #
 # A bash regex extracts the components and produces:
 #
-#     <maj>.<min>.<next-patch>-0.<label>.<count>
+#     <maj>.<min>.<next-patch>-0.<label>
 #
 # The leading "0" is a numeric SemVer identifier that sorts below any
 # alphanumeric pre-release label (alpha, beta, rc), ensuring non-pre-release
@@ -25,22 +25,20 @@
 # If the tag refers to a pre-release, like "<maj>.<min>.<patch>-<extra-stuff>",
 # the output will be:
 #
-#     <maj>.<min>.<patch>-<extra-stuff>.<label>.<count>
+#     <maj>.<min>.<patch>-<extra-stuff>.<label>
 #
-# The identifier order in both cases is: prerel > label > count, so that
-# SemVer ordering reflects: maj/min/patch > prerel > label > count.
-#
+# This preserves the expected SemVer ordering when any of the above change.
 # The label encodes the build context and is chosen so that SemVer ordering
 # reflects trustworthiness: branch push < PR < tag push < local build:
 #
-#     Branch push: <label> = "head.<branch-name>"
-#     PR build:    <label> = "pr.<pr-number>"
+#     Branch push: <label> = "head.<branch-name>.<count-from-tag>"
+#     PR build:    <label> = "pr.<pr-number>.<date-time>"
 #     Tag push:    <label> = "tag.<tag-name>"
 #     Local build: <label> = "wip.<date-time>"
 #
 # These are among the lowest possible SemVer versions greater than the last
 # tagged version. If there are no tags at all (for example when run in a fork
-# etc), it defaults to "9.9.9-<date>".
+# etc), it defaults to "9.9.9-<date-time>".
 #
 # Finally, non-exact-tag versions have a "+<commit-hash[-dirty]>" appended. The
 # commit hash used is taken from HEAD_REF if set - this is to ensure that in CI
@@ -51,14 +49,15 @@
 # VERSION format if a filename is provided as the first argument.
 
 # Determine pre-release label based on build context
+DATE="$(date -u '+%y%m%dT%H%MZ')"
 if [ -z "$GITHUB_ACTIONS" ]; then
 	# local build, highest precedence
 	KIND="wip"
-	NAME="$(date '+%Y%m%d-%H%M%S')"
+	NAME="$DATE"
 elif [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then
 	# CI build for a PR, medium precedence
 	KIND="pr"
-	NAME="$(jq -r .number < "$GITHUB_EVENT_PATH")"
+	NAME="$(jq -r .number < "$GITHUB_EVENT_PATH").$DATE"
 elif [[ "$GITHUB_REF" =~ ^refs/(heads|tags)/(.*) ]]; then
 	# CI build for a branch or tag push, lowest precedence
 	KIND="${BASH_REMATCH[1]%s}" # "heads" -> "head", "tags" -> "tag"
@@ -121,11 +120,11 @@ else
 			v_extra="-0"
 		fi
 
-		if [ "$KIND" == "tag" ] ; then
-			# number of commits since tag is irrelevant for a tag push
-			v_extra="${v_extra}.${KIND}.${NAME}"
-		else
+		if [ "$KIND" == "head" ] ; then
+			# number of commits since tag is only relevant for a branch push
 			v_extra="${v_extra}.${KIND}.${NAME}.${count}"
+		else
+			v_extra="${v_extra}.${KIND}.${NAME}"
 		fi
 
 		# If HEAD_REF is not set, we're not in CI but in a local clone. Use the

--- a/extra/gh-pr-url.sh
+++ b/extra/gh-pr-url.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Copyright (c) Arduino s.r.l. and/or its affiliated companies
+# SPDX-License-Identifier: Apache-2.0
+
+# Given a PR number, print the api.github.com link to the artifact produced by
+# the "package-index-json" step on the last "Package, test and upload core" run
+# for that PR.
+#
+# Designed to be installed in /usr/local/bin and be used as:
+#
+#   gh pr-url <pr-number> [repo]
+
+set -euo pipefail
+
+if [ $# -lt 1 ]; then
+	echo "Usage: $0 <pr-number> [repo]" >&2
+	exit 1
+fi
+
+PR_NUM="$1"
+REPO="${2:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}"
+
+PR_TAG="${REPO}#${PR_NUM}"
+
+BRANCH="$(gh pr view "${PR_NUM}" --json headRefName -q .headRefName)"
+RUN_ID="$(gh run list \
+	  --workflow package_core.yml \
+	  --branch "${BRANCH}" \
+	  --limit 1 \
+	  --json databaseId -q '.[0].databaseId')"
+
+if [ -z "${RUN_ID}" ]; then
+	echo "No CI run found for ${PR_TAG} (branch ${BRANCH})" >&2
+	exit 1
+fi
+
+ARTIFACT_NAME="package_arduino_zephyr_pr_${PR_NUM}_ci_index.json"
+
+ARTIFACT_ID="$(gh api "/repos/${REPO}/actions/runs/${RUN_ID}/artifacts" \
+	       -q ".artifacts[] | select(.name == \"${ARTIFACT_NAME}\") | .id")"
+
+if [ -z "${ARTIFACT_ID}" ]; then
+	echo "No package index found for ${PR_TAG} (CI run ${RUN_ID})"
+	exit 1
+fi
+
+echo "https://api.github.com/repos/${REPO}/actions/artifacts/${ARTIFACT_ID}/zip#${ARTIFACT_NAME}"


### PR DESCRIPTION
* On pull requests and pushes to the official ArduinoCore-zephyr repo, use the latest ci-builds JSON as a reference for building the core, if available. This allows to install the current set of tools required by the branch sources, instead of using those from the latest release.

* On pull requests to the official repo, the same logic is also used to compute a temporary package index that contains links to the PR's artifacts so that the CI build results can be directly installed locally and tested on an actual board. This feature requires an `arduino-cli` with arduino/arduino-cli#3227 applied, which can be found from [the nigthly build](https://docs.arduino.cc/arduino-cli/installation/#nightly-builds) page.