### PR TITLE
ci: build warning fixes

### DIFF
--- a/.github/workflows/package_core.yml
+++ b/.github/workflows/package_core.yml
@@ -397,6 +397,11 @@ jobs:
             ${{ env.ALL_TESTS }}
           libraries: |
             ${{ env.ALL_LIBRARIES }}
+          cli-compile-flags: |
+            - '--build-property'
+            - 'compiler.c.extra_flags=-Wno-type-limits -Wno-missing-field-initializers'
+            - '--build-property'
+            - 'compiler.cpp.extra_flags=-Wno-type-limits -Wno-missing-field-initializers'
           verbose: 'false'
           enable-deltas-report: 'false'
           enable-issues-report: 'true'

--- a/.github/workflows/package_core.yml
+++ b/.github/workflows/package_core.yml
@@ -515,6 +515,11 @@ jobs:
             ${{ env.ALL_TESTS }}
           libraries: |
             ${{ env.ALL_LIBRARIES }}
+          cli-compile-flags: |
+            - '--build-property'
+            - 'compiler.c.extra_flags=-Wno-type-limits -Wno-missing-field-initializers'
+            - '--build-property'
+            - 'compiler.cpp.extra_flags=-Wno-type-limits -Wno-missing-field-initializers'
           verbose: 'false'
           enable-deltas-report: 'false'
           enable-issues-report: 'true'

--- a/cores/arduino/Arduino.h
+++ b/cores/arduino/Arduino.h
@@ -8,6 +8,10 @@
 
 #include "api/ArduinoAPI.h"
 
+// redefined by Zephyr below
+#undef min
+#undef max
+
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/pwm.h>

--- a/cores/arduino/wiring_analog.cpp
+++ b/cores/arduino/wiring_analog.cpp
@@ -97,14 +97,11 @@ static const struct dac_channel_cfg dac_ch_cfg[] = {
 int _analog_write_resolution = 8;
 #endif
 
-// Note: We can not update the arduino_adc structure as it is read only...
-static int read_resolution = 10;
+} // anonymous namespace
 
 uint32_t map64(uint32_t x, uint32_t in_min, uint32_t in_max, uint32_t out_min, uint32_t out_max) {
 	return ((uint64_t)(x - in_min) * (out_max - out_min) / (in_max - in_min) + out_min);
 }
-
-} // anonymous namespace
 
 #if defined(CONFIG_DAC) || defined(CONFIG_PWM)
 void analogWriteResolution(int bits) {
@@ -183,6 +180,9 @@ void analogWrite(enum dacPins dacName, int value) {
 #endif
 
 #ifdef CONFIG_ADC
+
+// Note: We can not update the arduino_adc structure as it is read only...
+static int read_resolution = 10;
 
 void __attribute__((weak)) analogReference(uint8_t mode) {
 	/*

--- a/extra/ci_collect_data.py
+++ b/extra/ci_collect_data.py
@@ -134,12 +134,22 @@ for board_data in ALL_BOARD_DATA.values():
 
     # Get list of expected errors for this board
     exceptions = []
+    warning_filters = [] # [ (sketch_pattern, regex), ...]
     if os.path.exists(f"variants/{variant}/known_example_issues.txt"):
         with open(f"variants/{variant}/known_example_issues.txt", 'r') as f:
             for line in f:
-                sketch_pattern = line.split('#')[0].strip()
-                if sketch_pattern:
-                    exceptions.append(re.compile(f"^(ArduinoCore-zephyr/)?{sketch_pattern}"))
+                line = line.split('#')[0].strip()
+                if not line:
+                    continue
+                elif '|' in line:
+                    # this is a warning filter, not an exception
+                    sketch_pattern, warning_pattern = line.split('|', 1)
+                    sketch_pattern = re.compile(f"^(ArduinoCore-zephyr/)?{sketch_pattern}")
+                    warning_pattern = re.compile(warning_pattern)
+                    warning_filters.append(( sketch_pattern, warning_pattern ))
+                else:
+                    # this is an exception
+                    exceptions.append(re.compile(f"^(ArduinoCore-zephyr/)?{line}"))
 
     # Get raw data from report files for both static and dynamic linking modes
     for link_mode in ("static", "dynamic"):
@@ -175,6 +185,11 @@ for board_data in ALL_BOARD_DATA.values():
 
             # Replace long absolute paths with '...' for brevity.
             sketch_issues = [ re.sub(r'(/.+?)((/[^/]+){3}):', r'...\2:', issue) for issue in issues ]
+
+            # Remove known warnings, if any
+            for sketch_pattern, warning_pattern in warning_filters:
+                if sketch_pattern.match(sketch):
+                    sketch_issues = [ issue for issue in sketch_issues if not warning_pattern.search(issue) ]
 
             if not success:
                 status = ERROR

--- a/libraries/Arduino_LED_Matrix/examples/Reflash_Bootanimation/Reflash_Bootanimation.ino
+++ b/libraries/Arduino_LED_Matrix/examples/Reflash_Bootanimation/Reflash_Bootanimation.ino
@@ -22,7 +22,7 @@ void setup() {
 
     const struct flash_area *fa;
 	int rc;
-	rc = flash_area_open(FIXED_PARTITION_ID(bootanimation), &fa);
+	rc = flash_area_open(PARTITION_ID(bootanimation), &fa);
 	if (rc) {
 		return;
 	}

--- a/libraries/Camera/src/camera.cpp
+++ b/libraries/Camera/src/camera.cpp
@@ -57,7 +57,7 @@ struct video_buffer *user_video_buffer_aligned_alloc(size_t size, size_t align,
 													 k_timeout_t timeout) {
 	struct video_buffer *vbuf = NULL;
 	struct mem_block *block = NULL;
-	int i;
+	unsigned int i;
 
 	ARG_UNUSED(timeout);
 
@@ -104,7 +104,7 @@ struct video_buffer *user_video_buffer_aligned_alloc(size_t size, size_t align,
 
 int user_video_buffer_release(struct video_buffer *vbuf) {
 	struct mem_block *block = NULL;
-	int i;
+	unsigned int i;
 
 	if (vbuf == NULL) {
 		return -EINVAL;

--- a/libraries/SocketWrapper/ZephyrSSLClient.h
+++ b/libraries/SocketWrapper/ZephyrSSLClient.h
@@ -26,6 +26,11 @@ private:
 public:
 	ZephyrSSLClient();
 
+	int connect(IPAddress ip, uint16_t port) override {
+		String ipStr = ip.toString();
+		return connectSSL(ipStr.c_str(), port, nullptr);
+	}
+
 	int connect(const char *host, uint16_t port) override {
 #if defined(ARDUINO_MANAGES_MBEDTLS)
 		if (!mbedtls_is_ready) {

--- a/libraries/Storage/examples/FlashFormat/FlashFormat.ino
+++ b/libraries/Storage/examples/FlashFormat/FlashFormat.ino
@@ -129,7 +129,7 @@ int flashWiFiFirmware() {
     Serial.println(" bytes");
 
     const struct flash_area *fa;
-    int ret = flash_area_open(FIXED_PARTITION_ID(airoc_firmware), &fa);
+    int ret = flash_area_open(PARTITION_ID(airoc_firmware), &fa);
     if (ret) {
         Serial.print("Error opening airoc_firmware partition: ");
         Serial.println(ret);
@@ -165,7 +165,7 @@ int flashMBR() {
 
     // Open the MBR partition
     const struct flash_area *fa;
-    int ret = flash_area_open(FIXED_PARTITION_ID(mbr_partition), &fa);
+    int ret = flash_area_open(PARTITION_ID(mbr_partition), &fa);
     if (ret) {
         Serial.print("Error opening MBR partition: ");
         Serial.println(ret);

--- a/libraries/Storage/examples/PartitionInfo/PartitionInfo.ino
+++ b/libraries/Storage/examples/PartitionInfo/PartitionInfo.ino
@@ -35,7 +35,7 @@ void setup() {
 
     // Open the MBR partition to read the partition table
     const struct flash_area *fa;
-    int ret = flash_area_open(FIXED_PARTITION_ID(mbr_partition), &fa);
+    int ret = flash_area_open(PARTITION_ID(mbr_partition), &fa);
     if (ret) {
         Serial.println("ERROR! Unable to open flash device.");
         return;

--- a/platform.txt
+++ b/platform.txt
@@ -19,7 +19,7 @@ compiler.path={build.compiler_path}
 compiler.c.cmd={build.crossprefix}gcc
 compiler.c.flags=-g -Os -c {compiler.define} {compiler.warning_flags} {compiler.zephyr.macros} "@{compiler.zephyr.machine_flags_file}" "@{compiler.zephyr.cflags_file}" -fdata-sections -ffunction-sections -MMD
 compiler.c.elf.cmd={build.crossprefix}g++
-compiler.c.elf.flags=-Wl,--gc-sections "@{compiler.zephyr.machine_flags_file}" -std=gnu++17
+compiler.c.elf.flags=-Wl,--gc-sections -Wl,-z,noexecstack "@{compiler.zephyr.machine_flags_file}" -std=gnu++17
 compiler.S.cmd={build.crossprefix}g++
 compiler.S.flags=-c -x assembler-with-cpp "@{compiler.zephyr.machine_flags_file}"
 compiler.cpp.cmd={build.crossprefix}g++

--- a/variants/arduino_giga_r1_stm32h747xx_m7/known_example_issues.txt
+++ b/variants/arduino_giga_r1_stm32h747xx_m7/known_example_issues.txt
@@ -9,3 +9,10 @@
 # against the path of each sketch found in this repo. If a match is found, the
 # sketch compilation result will be ignored.
 
+# If the line contains a '|' (pipe) character, the part before the | is treated
+# as a regular expression to match against the sketch path, and the part after
+# the '|' is a regular expression to match against a reported issue. If both
+# match, the message will be ignored.
+
+# Loads of those in the lvgl library
+libraries/Arduino_Video/examples/LVGLDemo|warning: missing terminating " character

--- a/variants/arduino_portenta_h7_stm32h747xx_m7/known_example_issues.txt
+++ b/variants/arduino_portenta_h7_stm32h747xx_m7/known_example_issues.txt
@@ -8,3 +8,11 @@
 # Each line in this file is treated as a regular expression and will be matched
 # against the path of each sketch found in this repo. If a match is found, the
 # sketch compilation result will be ignored.
+
+# If the line contains a '|' (pipe) character, the part before the | is treated
+# as a regular expression to match against the sketch path, and the part after
+# the '|' is a regular expression to match against a reported issue. If both
+# match, the message will be ignored.
+
+# Loads of those in the lvgl library
+libraries/Arduino_Video/examples/LVGLDemo|warning: missing terminating " character


### PR DESCRIPTION
Squash core warning count.

Related library PRs and TODOs:
- [x] arduino-libraries/Arduino_GigaDisplayTouch#21 + new release
- [x] arduino-libraries/Arduino_SecureElement#45 + new release
- [x] new release of [Arduino_JSON](https://github.com/arduino-libraries/Arduino_JSON) (fix already on main)
- [x] investigate warnings on [Arduino_SE05x](https://github.com/arduino-libraries/Arduino_SE05x) "no enable pin defined"
- [x] merge arduino-libraries/Arduino_JSON#85 and re-release Arduino_JSON 
- [x] merge arduino-libraries/Arduino_BMI270_BMM150#78 and release Arduino_BMI270_BMM150 1.2.4
- [x] merge arduino-libraries/Arduino_HS300x#4 and release Arduino_HS300x 1.0.1
- [x] merge arduino-libraries/Arduino_LPS22HB#48 and release Arduino_LPS22HB 1.0.3
- [x] merge arduino-libraries/Arduino_GigaDisplayTouch#22 and release Arduino_GigaDisplayTouch
- [x] :warning: major cleanup needed for [Arduino_Video](https://github.com/arduino-libraries/Arduino_Video)
