### PR TITLE
json: unoq: update Arduino_RouterBridge to 0.4.3

### DIFF
--- a/extra/artifacts/zephyr_unoq.json
+++ b/extra/artifacts/zephyr_unoq.json
@@ -3,7 +3,7 @@
   "architecture": "zephyr",
   "category": "Arduino",
   "libraryDependencies": [
-    { "name":"Arduino_RouterBridge", "version":"0.4.2" },
+    { "name":"Arduino_RouterBridge", "version":"0.4.3" },
     { "name":"Arduino_RPClite", "version":"0.3.0" },
     { "name":"MsgPack", "version":"0.4.2" },
     { "name":"DebugLog", "version":"0.8.4" },


### PR DESCRIPTION
Arduino_RouterBridge 0.4.3 fixes maximum buffer size for udp and tcp client implementations