### PR TITLE
docs: correct typos and improve clarity in documentation files

### DIFF
--- a/documentation/arduino_libs.md
+++ b/documentation/arduino_libs.md
@@ -18,11 +18,11 @@ Let's assume the structure of your application for simplicity to be,
 Paste your library's source files like ``ADXL345.h`` and ``ADXL345.cpp`` in your project's src folder. 
 
 ## Update CMakeLists
-As we can see, there is a Top-level CMakelists which needs to be updated with your external library's source files.
+As we can see, there is a Top-level CMakeLists.txt which needs to be updated with your external library's source files.
 For example, we add `target_sources(app PRIVATE src/ADXL345.cpp)`  to CMakeLists.txt.
 
 ## Update main.cpp
-Finally, paste your required code using the library in ``main.c`` and include that library's header using
+Finally, paste your required code using the library in ``main.cpp`` and include that library's header using
 ```c
 #include "ADXL345.h"
 ```

--- a/documentation/dynamic_pinmux.md
+++ b/documentation/dynamic_pinmux.md
@@ -29,7 +29,7 @@ PINCTRL_STATE_SLEEP      = 1
 PINCTRL_STATE_PRIV_START = 2
 ```
 
-Custom state name arduino is defined in devicetree and mapped to PINCTRL_STATE_ARDUINO.
+The custom state name `arduino` is defined in devicetree and mapped to `PINCTRL_STATE_ARDUINO`.
 
 Typical mapping:
 
@@ -37,67 +37,67 @@ Typical mapping:
 - sleep: optional low-power/disconnected state (not used)
 - arduino: custom channel list used for per-pin restore (mainly ADC/PWM/DAC)
 
-## Runtime Infrastructure in zephyrPinctrl.cpp
+## Runtime Infrastructure in `zephyrPinctrl.cpp`
 
 The core builds a runtime map between devices and pinctrl configs. 
 
-Selection rule for nodes included in the map is node is zephyr,deferred-init.
-Because the Zephyr logging UART is intentionally not marked with zephyr,deferred-init for easier debugging, it is added to the pinctrl map via a dedicated mapping entry.
+The selection rule for nodes included in the map is that the node has `zephyr,deferred-init`.
+Because the Zephyr logging UART is intentionally not marked with `zephyr,deferred-init` for easier debugging, it is added to the pinctrl map via a dedicated mapping entry.
 
 The map is then used by APIs:
 
-- init_dev_apply_pinctrl(dev)
-- init_dev_apply_channel_pinctrl(dev, state_pin_idx)
+- `init_dev_apply_pinctrl(dev)`
+- `init_dev_apply_channel_pinctrl(dev, state_pin_idx)`
 
 If a device has no known pinctrl config in the map:
 
-- init_dev_apply_channel_pinctrl(...) returns -ENOTSUP,
-- init_dev_apply_pinctrl(...) still initializes the device/dependencies but skips pinctrl apply for entries
+- `init_dev_apply_channel_pinctrl(...)` returns `-ENOTSUP`,
+- `init_dev_apply_pinctrl(...)` still initializes the device/dependencies but skips pinctrl apply for entries
     not present in the map.
 
 ## Dynamic Pinmux APIs and Runtime Flow
 
-### init_dev_apply_pinctrl(dev)
+### `init_dev_apply_pinctrl(dev)`
 
 Purpose: initialize the target device and its dependencies, then apply the whole pinctrl
-PINCTRL_STATE_DEFAULT state where pinctrl configuration is known.
+`PINCTRL_STATE_DEFAULT` state where pinctrl configuration is known.
 
 Used for full peripheral remux, to restore the default state.
 
-SPI (SPI.begin), I2C (Wire.begin) and UART (ZephyrSerial::begin) calls init_dev_apply_pinctrl(dev), without taking care of device readiness/init.
+SPI (`SPI.begin`), I2C (`Wire.begin`) and UART (`ZephyrSerial::begin`) call `init_dev_apply_pinctrl(dev)`, without taking care of device readiness/init.
 
 Behavior details:
 
 - recursively initializes required dependencies first,
 - initializes each device on first use if needed,
-- applies PINCTRL_STATE_DEFAULT from known device pinctrl configs,
-- treats -ENOENT from pinctrl_apply_state as non-fatal (for empty/default-less states).
+- applies `PINCTRL_STATE_DEFAULT` from known device pinctrl configs,
+- treats `-ENOENT` from `pinctrl_apply_state` as non-fatal (for empty/default-less states).
 
-### init_dev_apply_channel_pinctrl(dev, state_pin_idx)
+### `init_dev_apply_channel_pinctrl(dev, state_pin_idx)`
 
-Purpose: apply only one pin from the device arduino state.
+Purpose: apply only one pin from the device `arduino` state.
 
-Used for channel-based peripherals (ADC/PWM/DAC) in the analogRead and analogWrite functions, allowing a single channel can be remuxed without touching sibling channels.
+Used for channel-based peripherals (ADC/PWM/DAC) in the `analogRead` and `analogWrite` functions, allowing a single channel to be remuxed without touching sibling channels.
 
 Behavior details:
 
 - initializes the device on first use if needed,
-- resolves PINCTRL_STATE_ARDUINO,
-- applies only one pin entry (state_pin_idx), with bounds checking.
+- resolves `PINCTRL_STATE_ARDUINO`,
+- applies only one pin entry (`state_pin_idx`), with bounds checking.
 
 Implementation pattern:
 
 - resolve analog/pwm index from pin,
-- compute a per-device ordinal index with state_pin_index_from_spec_index(arduino_adc/arduino_pwm, idx),
-- call init_dev_apply_channel_pinctrl(dev, per_dev_idx),
+- compute a per-device ordinal index with `state_pin_index_from_spec_index(arduino_adc/arduino_pwm, idx)`,
+- call `init_dev_apply_channel_pinctrl(dev, per_dev_idx)`,
 
-How state_pin_index_from_spec_index works:
+How `state_pin_index_from_spec_index` works:
 
-- spec_idx is the global position in the zephyr,user array (io-channels for ADC or pwms for PWM). For example, A1/D1 maps to spec_idx = 1 (second entry);
-- state_pin_index_from_spec_index(...) scans previous entries [0..spec_idx-1] and counts only those that reference the same device (i.e. the same PWM/ADC controller instance, such as pwm4);
-- the resulting count is the per-device ordinal (0, 1, 2, ...) used as state_pin_idx in the device arduino pinctrl state.
+- `spec_idx` is the global position in the `zephyr,user` array (`io-channels` for ADC or `pwms` for PWM). For example, A1/D1 maps to `spec_idx = 1` (second entry);
+- `state_pin_index_from_spec_index(...)` scans previous entries `[0..spec_idx-1]` and counts only those that reference the same device (i.e. the same PWM/ADC controller instance, such as `pwm4`);
+- the resulting count is the per-device ordinal (0, 1, 2, ...) used as `state_pin_idx` in the device `arduino` pinctrl state.
 
-Example (GIGA PWM list in zephyr,user):
+Example (GIGA PWM list in `zephyr,user`):
 
 ```dts
 pwms = <&pwm1 3 PWM_HZ(12000000) PWM_POLARITY_NORMAL>,
@@ -116,14 +116,14 @@ pwms = <&pwm1 3 PWM_HZ(12000000) PWM_POLARITY_NORMAL>,
        <&pwm1 1 PWM_HZ(5000) PWM_POLARITY_NORMAL>;
 ```
 
-If analogWrite() resolves to spec_idx = 8 (9th entry, `&pwm4 4`):
+If `analogWrite()` resolves to `spec_idx = 8` (9th entry, `&pwm4 4`):
 
-- device = pwm4
-- previous pwm4 entries are at spec_idx 5 and 7
+- device = `pwm4`
+- previous `pwm4` entries are at `spec_idx` 5 and 7
 - count of previous same-device entries = 2
-- state_pin_idx = 2 (zero-based)
+- `state_pin_idx = 2` (zero-based)
 
-Then init_dev_apply_channel_pinctrl(pwm4, 2) selects the 3rd entry of pwm4 `pinctrl-2`.
+Then `init_dev_apply_channel_pinctrl(pwm4, 2)` selects the 3rd entry of `pwm4` `pinctrl-2`.
 
 ```dts
 pwm4: pwm {
@@ -140,7 +140,7 @@ In this example, the selected pin is `tim4_ch4_pb9`.
 
 Effect:
 
-- only the requested ADC pad or PWM pad is remuxed to analog function.
+- only the requested ADC pad or PWM pad is remuxed to its target peripheral function.
 
 ## Devicetree Requirements
 
@@ -158,17 +158,17 @@ Use deferred init and provide usual default/sleep states.
 };
 ```
 
-Same pattern applies to i2cX and uartX.
+Same pattern applies to `i2cX` and `uartX`.
 
 Note: the runtime map explicitly includes the node selected as `zephyr,console` even when it is
-not deferred-init.
+not `deferred-init`.
 
-Recommendation: keep the UART used for early logs available from boot; if it is deferred-init,
+Recommendation: keep the UART used for early logs available from boot; if it is `deferred-init`,
 early error logs generated during system startup or sketch load may not be visible.
 
 ### For channel-based ADC/PWM/DAC nodes
 
-Use deferred init and keep channel pads in pinctrl-2 and name it arduino.
+Use deferred init and keep channel pads in `pinctrl-2` and name it `arduino`.
 
 ```dts
 &periphN {
@@ -185,16 +185,16 @@ Use deferred init and keep channel pads in pinctrl-2 and name it arduino.
 
 For each ADC/PWM device, ordering must match between:
 
-- zephyr,user spec arrays (io-channels or pwms), and
-- that device arduino pin list (pinctrl-2).
+- `zephyr,user` spec arrays (`io-channels` or `pwms`), and
+- that device `arduino` pin list (`pinctrl-2`).
 
-state_pin_index_from_spec_index() assumes this ordinal alignment to map a logical channel entry to the correct pin in the arduino state.
+`state_pin_index_from_spec_index()` assumes this ordinal alignment to map a logical channel entry to the correct pin in the `arduino` state.
 
 ## Known limitation - Nordic nRF
 
 On Nordic nRF targets, switching a pin from PWM back to another peripheral may leave PWM still affecting that pin unless PWM is explicitly stopped first.
 
-The reason is architectural: in the nRF pinctrl/driver model, pin routing is programmed per peripheral by writing that peripheral’s PSEL registers. Reconfiguring the new peripheral (i.e. SPI) updates SPI’s PSEL, but it does not automatically clear PWM’s PSEL ownership for the same physical pin.
+The reason is architectural: in the nRF pinctrl/driver model, pin routing is programmed per peripheral by writing that peripheral’s `PSEL` registers. Reconfiguring the new peripheral (i.e. SPI) updates SPI’s `PSEL`, but it does not automatically clear PWM’s `PSEL` ownership for the same physical pin.
 In our current core flow, we do not keep global runtime ownership tracking across peripherals for each pin, so we cannot reliably force-release the previous owner in all cases.
 
 This limitation is relevant only when the same pin was previously configured/driven by PWM and is now being reassigned to another peripheral.  

--- a/documentation/variants.md
+++ b/documentation/variants.md
@@ -1,10 +1,10 @@
-# Adding custom boards/ variants
+# Adding custom boards/variants
 
 - Boards already supported by Zephyr can be added to the variants folder as outlined in this documentation.
-- Custom boards can first by added by following the [official Zephyr porting guide](https://docs.zephyrproject.org/latest/hardware/porting/board_porting.html).
+- Custom boards can first be added by following the [official Zephyr porting guide](https://docs.zephyrproject.org/latest/hardware/porting/board_porting.html).
 Once completed, continue here by adding a variant for your custom board.
 
-## Suppored Boards/variants
+## Supported Boards/variants
 
 - [X] Arduino Nano ble sense 33
 - [X] Arduino Nano ble 33
@@ -26,7 +26,7 @@ target board. To add board support:
 1. This project is structured in a way so as to isolate the variants from the core API. Thus, whenever a new board
 needs to be added it needs to be done in the `variants/` folder.
 Add a folder inside of the variants folder that matches the name of your board.
-2. Add an overlay file file that match the name of the board.
+2. Add an overlay file that matches the name of the board.
 3. Add a `variant.h` file.
 
 An example of this structure is shown below.
@@ -45,12 +45,18 @@ variants/
 The Arduino API requires pin mapping definitions to use Arduino-style pin numbers
 (pin numbers printed on the board, not GPIO numbers).
 The pin-mapping node is under the `zephyr,user` node of DTS.
-`digital-pin-gpios` defines digital input/output pins that is D0, D1, ..,
-`adc-pin-gpios` defines analog input pins that is A0, A1, ... .
+`digital-pin-gpios` defines digital input/output pins, i.e. D0, D1, ...,
+`adc-pin-gpios` defines analog input pins, i.e. A0, A1, etc.
 `pwm-pin-gpios` defines PWM pins.
 Each pin specifies in the form of a GPIO cell.
 Usually, it is in the form of `<[port] [pin-number] [flag]>`.
 You can also use the Arduino header node definition here.
+
+> [!NOTE]
+> For phandle-array properties like these (`digital-pin-gpios`, `adc-pin-gpios`,
+> `pwm-pin-gpios`, `serials`, `i2cs`, etc.), both `<&dev1 &dev2>` (multiple entries in a
+> single bracket group) and `<&dev1>, <&dev2>` (separate bracket groups joined by commas)
+> are valid DTS syntax. However, `<&dev1, &dev2>` is **invalid**.
 
 ### Overlays using previously-defined Arduino headers
 
@@ -66,18 +72,17 @@ uses [the Arduino header definitions](https://github.com/zephyrproject-rtos/zeph
 ```
 / {
 	zephyr,user {
-		digital-pin-gpios = <&arduino_header 6 0>,	/* Digital */
-				    <&arduino_header 7 0>;
-				    ...
-				    <&arduino_header 19 0>;
-				    <&arduino_header 0 0>;	/* Analog */
-				    <&arduino_header 1 0>;
-				    ...
-				    <&arduino_header 5 0>;
-				    <&arduino_header 20 0>;	/* SDA */
-				    <&arduino_header 21 0>;	/* SCL */
-				    <&gpio0 13 GPIO_ACTIVE_LOW>;	/* LED0 */
-		};
+		digital-pin-gpios = <&arduino_header 6 0>, /* Digital */
+			    <&arduino_header 7 0>,
+			    ...
+			    <&arduino_header 19 0>,
+			    <&arduino_header 0 0>, /* Analog */
+			    <&arduino_header 1 0>,
+			    ...
+			    <&arduino_header 5 0>,
+			    <&arduino_header 20 0>, /* SDA */
+			    <&arduino_header 21 0>, /* SCL */
+			    <&gpio0 13 GPIO_ACTIVE_LOW>; /* LED0 */
 	};
 };
 ```
@@ -85,15 +90,15 @@ uses [the Arduino header definitions](https://github.com/zephyrproject-rtos/zeph
 ### Configure Serial devices
 
 The `serials` node defines the Serial devices to use.
-It instantiate the `Serial` with the UART device that contained in the node.
-Also instantiate as `Serial1`, `Serial2`, .. `SerialN` with the devices that is
-after the second in the case of the array contains plural devices.
+It instantiates `Serial` with the UART device contained in the node.
+Also instantiates `Serial1`, `Serial2`, ... `SerialN` with the devices
+after the first when the array contains more than one device.
 
-If the `serials` node is not defined, Use the node labeled `arduino-serial`.
+If the `serials` node is not defined, use the node labeled `arduino-serial`.
 Boards with Arduino-shield style connectors usually label `arduino-serial` for
 UART port exposed in header or frequently used UART port.
 
-If even 'arduino_serial' does not define, it uses the stub implementation
+If even `arduino_serial` is not defined, it uses the stub implementation
 that redirects to printk().
 
 The following example instantiates `Serial` and `Serial1` with each `uart0` and `uart1`.
@@ -101,7 +106,7 @@ The following example instantiates `Serial` and `Serial1` with each `uart0` and 
 ```
 / {
        zephyr,user {
-               serials = <&uart0, &uart1>;
+               serials = <&uart0>, <&uart1>;
        };
 };
 ```
@@ -109,20 +114,20 @@ The following example instantiates `Serial` and `Serial1` with each `uart0` and 
 ### Configure I2C devices
 
 The `i2cs` node defines the I2C devices to use.
-It instantiate the `Wire` with the i2c device that contained in the node.
-Also instantiate as `Wire1`, `Wire2`, .. `WireN` with the devices
-that is after the second in the case of the array contains plural devices.
+It instantiates `Wire` with the i2c device contained in the node.
+Also instantiates `Wire1`, `Wire2`, ... `WireN` with the devices
+after the first when the array contains more than one device.
 
-If the `i2cs` node is not defined, Use the node labeled `arduino-i2c`.
+If the `i2cs` node is not defined, use the node labeled `arduino-i2c`.
 Boards with Arduino-shield style connectors usually label `arduino-i2c`
 to i2c exposed in the connector.
 
-The following example instantiates `Wire` and `Wire2` with each `i2c0` and `i2c1`.
+The following example instantiates `Wire` and `Wire1` with each `i2c0` and `i2c1`.
 
 ```
 / {
        zephyr,user {
-               i2cs = <&i2c0, &i2c1>;
+               i2cs = <&i2c0 &i2c1>;
        };
 };
 ```
@@ -135,16 +140,15 @@ array to find the index of the pin.
 
 The node is phandle-array, which uses the format same as `digital-pin-gpios`.
 
-It set the digital pin number to the `LED_BUILTIN` if found the pin
-that defined in `builtin-led-gpios` from `digital-pin-gpios`.
+It sets the digital pin number to `LED_BUILTIN` if the pin
+defined in `builtin-led-gpios` is found in `digital-pin-gpios`.
 
-If the `builtin-led-gpios` is not defined, Use the node aliased as `led0`
+If the `builtin-led-gpios` is not defined, use the node aliased as `led0`
 to define `LED_BUILTIN`.
 
-The `LED_BUILTIN` does not define here if it has not found both nodes or
-defined `LED_BUILTIN` already.
+`LED_BUILTIN` is not defined if neither node is found or `LED_BUILTIN` is already defined.
 
-For example, in the case of the 13th digital pins connected to the onboard LED,
+For example, in the case of the 13th digital pin connected to the onboard LED,
 define `builtin-led-gpios` as follows.
 
 ```
@@ -160,7 +164,7 @@ define `builtin-led-gpios` as follows.
 You can see in the example above that there is no mapping for `LED0` in the
 board's Arduino header definition so it has been added using the Zephyr `gpios`
 syntax (port, pin, flags). When creating an overlay file that doesn't have an
-Arduino header defined, you should follow this syntax for adding all pins
+Arduino header defined, you should follow this syntax for adding all pins.
 
 ### You control the pin mapping
 
@@ -168,7 +172,7 @@ Zephyr [chooses to map Arduino headers beginning with the Analog
 pins](https://docs.zephyrproject.org/latest/build/dts/api/bindings/gpio/arduino-header-r3.html),
 but the overlay file example above begins with the digital pins. This is to
 match user
-expectation that issuing `pinMode(0,OUTPUT);` should control digital pin 0 (and
+expectations that issuing `pinMode(0,OUTPUT);` should control digital pin 0 (and
 not pin 6). In the same way, the Analog 0 pin was mapped to D14 as this is
 likely what a shield made for the Arduino Uno R3 header would expect.
 


### PR DESCRIPTION
This PR aims to correct documentation spelling mistakes as well as misinformation.

The affected files are markdown files in the `documentation/` folder.

There are changes to the code, thereby leaving functionality untouched.