### PR TITLE
llext: export gmtime

### DIFF
--- a/loader/llext_exports.c
+++ b/loader/llext_exports.c
@@ -322,6 +322,7 @@ EXPORT_SYMBOL(k_work_submit_to_queue);
 EXPORT_SYMBOL(time);
 EXPORT_SYMBOL(sys_clock_settime);
 EXPORT_SYMBOL(mktime);
+EXPORT_SYMBOL(gmtime);
 
 EXPORT_SYMBOL(printf);
 EXPORT_SYMBOL(sprintf);


### PR DESCRIPTION
This PR enables libc `gmtime` that converts epoch time into broken down time