### PR TITLE
unoq: silence bogus error if loader/sketch needs reflashing

### DIFF
--- a/variants/arduino_uno_q_stm32u585xx/flash_sketch.cfg
+++ b/variants/arduino_uno_q_stm32u585xx/flash_sketch.cfg
@@ -2,16 +2,26 @@
 # SPDX-License-Identifier: Apache-2.0
 
 reset_config srst_only srst_nogate srst_push_pull connect_assert_srst
+if {$::tcl_platform(platform) eq "windows"} {
+	set null_device NUL
+} else {
+	set null_device /dev/null
+}
 init
 reset
 halt
 flash info 0
+log_output $null_device
 if {[catch {flash verify_image ${filename0}}] != 0} {
+	log_output default
 	flash write_image erase ${filename0}
 }
+log_output $null_device
 if {[catch {flash verify_image ${filename1} 0x8100000 bin}] != 0} {
+	log_output default
 	flash write_image erase ${filename1} 0x8100000 bin
 }
+log_output default
 reset
 sleep 100
 mww 0x40036400 0xCAFFEEEE


### PR DESCRIPTION
Should fix https://github.com/arduino/ArduinoCore-zephyr/issues/542

Needs to be tested on ~Windows~ (tested, ok) and Mac