### PR TITLE
tools: require arduino/scripting-tools 0.0.7

### DIFF
--- a/extra/artifacts/_common.json
+++ b/extra/artifacts/_common.json
@@ -67,6 +67,11 @@
       "packager": "arduino",
       "name": "bin2uf2",
       "version": "0.1.0"
+    },
+    {
+      "packager": "arduino",
+      "name": "scripting-tools",
+      "version": "0.0.7"
     }
   ]
 }


### PR DESCRIPTION
Needed for automatic loader updates on USB-based boards.