### PR TITLE
tools: require arduino/rp2040tools 1.1.0-rc1

### DIFF
--- a/extra/artifacts/_common.json
+++ b/extra/artifacts/_common.json
@@ -72,6 +72,11 @@
       "packager": "arduino",
       "name": "scripting-tools",
       "version": "0.0.7"
+    },
+    {
+      "packager": "arduino",
+      "name": "rp2040tools",
+      "version": "1.1.0-rc1"
     }
   ]
 }


### PR DESCRIPTION
Tool was missing and needed for nano_connect
Version 1.1.0 adds the possibility to skip elf2uf2 conversion and allows multiple consequential updates