### PR TITLE
fix(build): preserve quoted `zephyr_args` with spaces

### DIFF
--- a/extra/build.sh
+++ b/extra/build.sh
@@ -47,18 +47,22 @@ if ! [ -z "$chosen_board" ]; then
 	# found, use the target and args from there
 	board=$(jq -cr '.board' <<< "$chosen_board")
 	target=$(jq -cr '.target' <<< "$chosen_board")
-	args=$(jq -cr '.args' <<< "$chosen_board")
+	# the args field is a single string; split it on unquoted whitespace,
+	# keeping quotes so a quoted value with spaces stays one array element
+	arg_token='(?:[^\s"'\'']+|"[^"]*"|'\''[^'\'']*'\'')+'
+	mapfile -t args < <(jq -cr '.args' <<< "$chosen_board" | grep -oP "$arg_token")
 	upload_offset=$(jq -cr '.upload_offset' <<< "$chosen_board")
 
 	# Check for debug flag and append
 	if [ x$2 == x"--debug" ]; then
-		args="$args -- -DEXTRA_CONF_FILE=../extra/debug.conf"
+		args+=(-- -DEXTRA_CONF_FILE=../extra/debug.conf)
 	fi
 else
 	# expect Zephyr-compatible target and args
 	target=$1
 	shift
-	args="$*"
+	# keep each argument as a separate array element to preserve quoting
+	args=("$@")
 	chosen_board=$(extra/get_board_details.sh | jq -cr ".[] | select(.target == \"$target\") // empty")
 	if [ ! -z "$chosen_board" ]; then
 		board=$(jq -cr '.board' <<< "$chosen_board")
@@ -73,7 +77,7 @@ build_version=$(extra/get_core_version.sh loader/VERSION)
 
 echo
 echo "Build version: $build_version"
-echo "Build target: $target $args"
+echo "Build target: $target ${args[*]}"
 
 # Get the variant name (NORMALIZED_BOARD_TARGET in Zephyr)
 variant=$(extra/get_variant_name.sh $target)
@@ -89,7 +93,7 @@ fi
 BUILD_DIR=build/${variant}
 VARIANT_DIR=variants/${variant}
 rm -rf ${BUILD_DIR}
-west build -d ${BUILD_DIR} -b ${target} loader -t llext-edk ${args}
+west build -d ${BUILD_DIR} -b ${target} loader -t llext-edk "${args[@]}"
 
 # Extract the generated EDK tarball and copy it to the variant directory
 mkdir -p ${VARIANT_DIR} firmwares


### PR DESCRIPTION
`$*` plus unquoted `${args}` word-split quoted `-D` values on every space, dropping tokens after the first (see #549 for an example). The fix is twofold:

- for command line args, store them in a Bash array to keep boundaries intact through `west build`; 
- for the `zephyr_args` in `boards.txt`, tokenize the string on unquoted whitespace only, preserving the quotes so a quoted value with spaces stays a single argument. Done via a custom regex to keep the quotes intact. 

Fixes #549.