### PR TITLE
link: check no iterable section macros in the sketch

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -122,12 +122,12 @@ recipe.ar.pattern="{compiler.path}{compiler.ar.cmd}" {compiler.ar.flags} {compil
 
 ## Combine gc-sections, archives, and objects - Multi-pass linking
 recipe.c.combine.1.pattern={build.check_command-{build.link_mode}}
-recipe.c.combine.2.pattern={build.link_command} {build.link_args.build-{build.link_mode}} "-Wl,-Map,{build.path}/{build.project_name}_temp.map" -o "{build.path}/{build.project_name}_temp.elf"
+recipe.c.combine.2.pattern={build.link_command} "-T{build.ldscript.path}/sections-check.ld" {build.link_args.build-{build.link_mode}} "-Wl,-Map,{build.path}/{build.project_name}_temp.map" -o "{build.path}/{build.project_name}_temp.elf"
 recipe.c.combine.3.pattern="{runtime.tools.gen-rodata-ld.path}/gen-rodata-ld" "{build.path}/{build.project_name}_temp.elf" "{build.path}/rodata_split.ld" "{build.link_mode}"
 recipe.c.combine.4.pattern={build.link_command} "-T{build.path}/rodata_split.ld" {build.link_args.build-{build.link_mode}} {build.link_args.build-common}
 
 ## Combine gc-sections, archives, and objects - Single-pass linking (older IDEs)
-recipe.c.combine.pattern={build.link_command} {build.link_args.build-{build.link_mode}} -T{build.ldscript.path}/build-rodata.ld {build.link_args.build-common}
+recipe.c.combine.pattern={build.link_command} "-T{build.ldscript.path}/sections-check.ld" {build.link_args.build-{build.link_mode}} -T{build.ldscript.path}/build-rodata.ld {build.link_args.build-common}
 
 recipe.hooks.linking.postlink.1.pattern="{compiler.path}{build.crossprefix}strip" --strip-debug "{build.path}/{build.project_name}_debug.elf" -o "{build.path}/{build.project_name}.elf"
 

--- a/variants/_ldscripts/sections-check.ld
+++ b/variants/_ldscripts/sections-check.ld
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) Arduino s.r.l. and/or its affiliated companies
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* 
+ * Stop the build if Zephyr iterable section macros are used in the code. This
+ * is not supported by LLEXT and will cause silent issues in the final binary.
+ */
+
+SECTIONS {
+  .unexpected_iterables (INFO) : { *(SORT(._*.static.*_)) }
+  ASSERT(SIZEOF(.unexpected_iterables) == 0,
+         "error: Zephyr macros that define static objects are not supported in sketches. Use runtime allocation instead."
+  )
+}


### PR DESCRIPTION
This commit adds a new linker script, `sections-check.ld`, which checks for the presence of Zephyr iterable section macros in the sketch, resulting in `_*.static.*_` sections in the final binary. These macros are not supported by LLEXT and can be the source of silent issues in the final binary.

If any such sections are found, the build fails with an error message indicating that runtime allocation should be used instead.