### PR TITLE
SerialUSB: Use base write() overloads to fix Serial.write("str") compilation.

### DIFF
--- a/cores/arduino/SerialUSB.h
+++ b/cores/arduino/SerialUSB.h
@@ -34,6 +34,8 @@ public:
 		return write(&data, 1);
 	}
 
+	using Print::write;
+
 	void flush() override;
 
 protected:


### PR DESCRIPTION
Fixes #555