### PR TITLE
boards: H7: add other carrier pins to pin table

### DIFF
--- a/variants/arduino_portenta_h7_stm32h747xx_m7/arduino_portenta_h7_stm32h747xx_m7.overlay
+++ b/variants/arduino_portenta_h7_stm32h747xx_m7/arduino_portenta_h7_stm32h747xx_m7.overlay
@@ -421,7 +421,70 @@ qspi_flash: &mx25l12833f {};
 				    <&gpiok 5 0>,		/* LEDR */
 				    <&gpiok 6 0>,		/* LEDG */
 				    <&gpiok 7 0>,		/* LEDB */
-				    <&gpioi 12 0>;		/* SE05X_EN */
+				    <&gpioi 12 0>,		/* SE05X_EN */
+
+				    /* Other GPIO pins on J1/J2 duplicates removed */
+				    /* System devices like SDRam pins also removed */
+
+  					<&gpioa 0 GPIO_ACTIVE_LOW>,
+  					<&gpioa 11 GPIO_ACTIVE_LOW>,
+  					<&gpioa 12 GPIO_ACTIVE_LOW>,
+  					<&gpioa 13 GPIO_ACTIVE_LOW>,
+  					<&gpioa 14 GPIO_ACTIVE_LOW>,
+
+  					<&gpiob 2 GPIO_ACTIVE_LOW>,
+  					<&gpiob 3 GPIO_ACTIVE_LOW>,
+  					<&gpiob 4 GPIO_ACTIVE_LOW>,
+  					<&gpiob 6 GPIO_ACTIVE_LOW>,
+  					<&gpiob 7 GPIO_ACTIVE_LOW>,
+  					<&gpiob 8 GPIO_ACTIVE_LOW>,
+  					<&gpiob 9 GPIO_ACTIVE_LOW>,
+  					<&gpiob 14 GPIO_ACTIVE_LOW>,
+  					<&gpiob 15 GPIO_ACTIVE_LOW>,
+
+  					<&gpioc 13 GPIO_ACTIVE_LOW>,
+  					<&gpioc 15 GPIO_ACTIVE_LOW>,
+
+  					<&gpiod 3 GPIO_ACTIVE_LOW>,
+  					<&gpiod 4 GPIO_ACTIVE_LOW>,
+  					<&gpiod 5 GPIO_ACTIVE_LOW>,
+  					<&gpiod 6 GPIO_ACTIVE_LOW>,
+  					<&gpiod 7 GPIO_ACTIVE_LOW>,
+
+  					<&gpioe 2 GPIO_ACTIVE_LOW>,
+  					<&gpioe 3 GPIO_ACTIVE_LOW>,
+
+  					<&gpiog 3 GPIO_ACTIVE_LOW>,
+  					<&gpiog 9 GPIO_ACTIVE_LOW>,
+  					<&gpiog 10 GPIO_ACTIVE_LOW>,
+  					<&gpiog 14 GPIO_ACTIVE_LOW>,
+
+  					<&gpioh 6 GPIO_ACTIVE_LOW>,
+  					<&gpioh 9 GPIO_ACTIVE_LOW>,
+  					<&gpioh 10 GPIO_ACTIVE_LOW>,
+  					<&gpioh 11 GPIO_ACTIVE_LOW>,
+  					<&gpioh 12 GPIO_ACTIVE_LOW>,
+  					<&gpioh 13 GPIO_ACTIVE_LOW>,
+  					<&gpioh 14 GPIO_ACTIVE_LOW>,
+
+  					<&gpioi 2 GPIO_ACTIVE_LOW>,
+  					<&gpioi 3 GPIO_ACTIVE_LOW>,
+  					<&gpioi 4 GPIO_ACTIVE_LOW>,
+  					<&gpioi 5 GPIO_ACTIVE_LOW>,
+  					<&gpioi 6 GPIO_ACTIVE_LOW>,
+  					<&gpioi 7 GPIO_ACTIVE_LOW>,
+  					<&gpioi 8 GPIO_ACTIVE_LOW>,
+  					<&gpioi 9 GPIO_ACTIVE_LOW>,
+  					<&gpioi 10 GPIO_ACTIVE_LOW>,
+  					<&gpioi 13 GPIO_ACTIVE_LOW>,
+  					<&gpioi 14 GPIO_ACTIVE_LOW>,
+  					<&gpioi 15 GPIO_ACTIVE_LOW>,
+
+  					<&gpioj 6 GPIO_ACTIVE_LOW>,
+  					<&gpioj 7 GPIO_ACTIVE_LOW>,
+  					<&gpioj 8 GPIO_ACTIVE_LOW>,
+  					<&gpioj 9 GPIO_ACTIVE_LOW>,
+  					<&gpioj 10 GPIO_ACTIVE_LOW>;
 
 		builtin-led-gpios = <&gpiok 6 0>,
 				    <&gpiok 5 0>,


### PR DESCRIPTION
This should at least partially resolve: #388

As I have mentioned in a few places, currently there is no way within the ArduinoCore-zephyr for an app or library to address many of the IO pins of the H7.

Currently only those that are on the exterior edge of the board and LEDs and one or two others can be used.

As I have mentioned in other places such as:
https://forum.arduino.cc/t/digitalwritefast-pinname-and-other-zephyr-hacks/1452815/3 I have my own library that allows me to address all of the pins by pin name, on those boards that are STM32 based, but there should be a standard way.

like your MBED implementation, I added in all of the pins in GPIO name / pin order after all of the others.

However, I removed all of the duplicates, that is as GPIOH_15 is pin 0, I did not add this again as at least earlier this would break the code that generates the Arduino pin table from the device tree.

I also removed several of the pins that are directly tied to on board hardware such as the SDRAM.

With my pin test, so far I have rung out most of the breakout board and for all of the pins that are exported by the H7, they are showing up now with pin numbers (in addition to their pin name)