### PR TITLE
frdm_mcxn947: extend digital-pin-gpios to D0-D15 (incl. SW2/SW3)

### DIFF
--- a/variants/frdm_mcxn947_mcxn947_cpu0/frdm_mcxn947_mcxn947_cpu0.overlay
+++ b/variants/frdm_mcxn947_mcxn947_cpu0/frdm_mcxn947_mcxn947_cpu0.overlay
@@ -26,8 +26,25 @@
 
 / {
 	zephyr,user {
-		digital-pin-gpios = <&gpio0 10 GPIO_ACTIVE_LOW>, <&gpio0 27 GPIO_ACTIVE_LOW>, <&gpio1 2 GPIO_ACTIVE_LOW>;
+		digital-pin-gpios =
+			<&gpio4 3  GPIO_ACTIVE_HIGH>,  /* D0  = P4_3  */
+			<&gpio4 2  GPIO_ACTIVE_HIGH>,  /* D1  = P4_2  */
+			<&gpio0 29 GPIO_ACTIVE_HIGH>,  /* D2  = P0_29 */
+			<&gpio1 23 GPIO_ACTIVE_HIGH>,  /* D3  = P1_23 */
+			<&gpio0 30 GPIO_ACTIVE_HIGH>,  /* D4  = P0_30 */
+			<&gpio1 21 GPIO_ACTIVE_HIGH>,  /* D5  = P1_21 */
+			<&gpio1 2  GPIO_ACTIVE_HIGH>,   /* D6  = P1_2  (LED_BLUE共用) */
+			<&gpio0 31 GPIO_ACTIVE_HIGH>,  /* D7  = P0_31 */
+			<&gpio0 28 GPIO_ACTIVE_HIGH>,  /* D8  = P0_28 */
+			<&gpio0 10 GPIO_ACTIVE_HIGH>,   /* D9  = P0_10 (LED_RED共用) */
+			<&gpio0 27 GPIO_ACTIVE_HIGH>,   /* D10 = P0_27 (LED_GREEN共用, SPI SS) */
+			<&gpio0 24 GPIO_ACTIVE_HIGH>,  /* D11 = P0_24 (SPI MOSI) */
+			<&gpio0 26 GPIO_ACTIVE_HIGH>,  /* D12 = P0_26 (SPI MISO) */
+			<&gpio0 25 GPIO_ACTIVE_HIGH>,  /* D13 = P0_25 (SPI SCK) */
+			<&gpio0 23 GPIO_ACTIVE_HIGH>,  /* D14 = P0_23 (SW2, ARD_A5と共用) */
+			<&gpio0 6  GPIO_ACTIVE_HIGH>;  /* D15 = P0_6  (SW3) */
 		builtin-led-gpios = <&gpio0 10 GPIO_ACTIVE_LOW>, <&gpio0 27 GPIO_ACTIVE_LOW>, <&gpio1 2 GPIO_ACTIVE_LOW>;
+
 		cdc-acm-serial = <&board_cdc_acm_uart>; /* 'Serial' object is managed by SerialUSB */
 		serials = <&flexcomm4_lpuart4>; /* 'Serial1' onwards */
 		i2cs = <&flexcomm2_lpi2c2>;


### PR DESCRIPTION
## Summary

Extends `digital-pin-gpios` for the `frdm_mcxn947` variant from 3 entries
(shared with the onboard RGB LED only) to 16 entries, covering D0-D13
(all pins on the Arduino-compatible header) plus D14/D15 for the
onboard user buttons SW2/SW3.

## Motivation

Previously, `digital-pin-gpios` only exposed the 3 GPIOs shared with the
RGB LED (P0_10, P0_27, P1_2), leaving the rest of the Arduino header
pins (D0-D5, D7, D8, D11-D13) unusable from the Arduino API. This PR
maps all header pins to their physical MCU pins per the official
FRDM-MCXN947 User Manual (UM12018) Arduino header pinout table.

## Changes

- `digital-pin-gpios`: extended from 3 to 16 entries (D0-D15)
- Physical pin mapping verified against UM12018 and cross-checked
  against the existing SPI/I2C aliases already present in the overlay
- GPIO polarity (`GPIO_ACTIVE_HIGH`/`LOW`) verified on real hardware
  for every pin; 4 pins (D1, D6, D9, D10) required `GPIO_ACTIVE_LOW`
  due to how they're wired (D6/D9/D10 are shared with the RGB LED)
- D14/D15 map to the onboard user buttons SW2 (P0_23) and SW3 (P0_6),
  following the same pattern already used for onboard buttons in
  other variants (e.g. `arduino_opta`, `beagleconnect_freedom`,
  `arduino_nano_matter`)
- `builtin-led-gpios` is unchanged; LED_BUILTIN resolution is by
  physical pin match, so it continues to work correctly regardless of
  array order

## Testing

Verified on real FRDM-MCXN947 hardware via Arduino IDE (LinkServer
upload):
- `digitalWrite`/`digitalRead` on all of D0-D15
- `attachInterrupt`/`detachInterrupt` (all edge/level modes) on D2 and
  on SW2/SW3 (D14/D15)
- `LED_BUILTIN` (RGB LED) still works as before

## Notes

- D14/D15 (SW2/SW3) were deliberately placed here instead of after
  D13, because A0/A1 do not appear to have a corresponding GPIO-
  capable pin (they are documented only as `ADC0_A0`/`ADC0_B0`,
  unlike A2-A5 which map to `P0_14`/`P0_22`/`P0_15`/`P0_23`). Since
  A0/A1 cannot be assigned to `digital-pin-gpios`, that slot in the
  numbering was effectively free, so SW2/SW3 were placed there
  instead of being appended after D19.
- D16-D19 are intentionally left unassigned, reserved for future
  analog pins A2-A4 and I2C (SDA/SCL), matching the numbering already
  used in the official Arduino header silkscreen/schematic
  (`ARD_D18`/`ARD_D19` = I2C SDA/SCL).
- D10-D13 remain shared with the SPI peripheral pins, consistent with
  standard Arduino board conventions.