### PR TITLE
loader: exports: add missing float (32-bit) AEABI helpers

### DIFF
--- a/cores/arduino/llext_wrappers.c
+++ b/cores/arduino/llext_wrappers.c
@@ -195,8 +195,17 @@ VN(__aeabi_dcmple)
 VN(__aeabi_dcmpgt)
 VN(__aeabi_dcmpge)
 VN(__aeabi_dcmpun)
+/* float arithmetic */
+VN(__aeabi_fadd)
+VN(__aeabi_fsub)
+VN(__aeabi_fmul)
+VN(__aeabi_fdiv)
 /* float comparisons */
+VN(__aeabi_fcmpeq)
+VN(__aeabi_fcmplt)
 VN(__aeabi_fcmple)
+VN(__aeabi_fcmpgt)
+VN(__aeabi_fcmpge)
 VN(__aeabi_fcmpun)
 /* double <-> integer conversions */
 VN(__aeabi_d2iz)
@@ -209,6 +218,10 @@ VN(__aeabi_ul2d)
 /* float <-> double / integer conversions */
 VN(__aeabi_d2f)
 VN(__aeabi_f2d)
+VN(__aeabi_i2f)
+VN(__aeabi_ui2f)
+VN(__aeabi_f2iz)
+VN(__aeabi_f2uiz)
 VN(__aeabi_l2f)
 VN(__aeabi_ul2f)
 /* integer division */

--- a/loader/llext_exports.c
+++ b/loader/llext_exports.c
@@ -360,8 +360,17 @@ EXPORT_AEABI_SYM(__aeabi_dcmple);
 EXPORT_AEABI_SYM(__aeabi_dcmpgt);
 EXPORT_AEABI_SYM(__aeabi_dcmpge);
 EXPORT_AEABI_SYM(__aeabi_dcmpun);
+/* float arithmetic */
+EXPORT_AEABI_SYM(__aeabi_fadd);
+EXPORT_AEABI_SYM(__aeabi_fsub);
+EXPORT_AEABI_SYM(__aeabi_fmul);
+EXPORT_AEABI_SYM(__aeabi_fdiv);
 /* float comparisons */
+EXPORT_AEABI_SYM(__aeabi_fcmpeq);
+EXPORT_AEABI_SYM(__aeabi_fcmplt);
 EXPORT_AEABI_SYM(__aeabi_fcmple);
+EXPORT_AEABI_SYM(__aeabi_fcmpgt);
+EXPORT_AEABI_SYM(__aeabi_fcmpge);
 EXPORT_AEABI_SYM(__aeabi_fcmpun);
 /* double <-> integer conversions */
 EXPORT_AEABI_SYM(__aeabi_d2iz);
@@ -374,6 +383,10 @@ EXPORT_AEABI_SYM(__aeabi_ul2d);
 /* float <-> double / integer conversions */
 EXPORT_AEABI_SYM(__aeabi_d2f);
 EXPORT_AEABI_SYM(__aeabi_f2d);
+EXPORT_AEABI_SYM(__aeabi_i2f);
+EXPORT_AEABI_SYM(__aeabi_ui2f);
+EXPORT_AEABI_SYM(__aeabi_f2iz);
+EXPORT_AEABI_SYM(__aeabi_f2uiz);
 EXPORT_AEABI_SYM(__aeabi_l2f);
 EXPORT_AEABI_SYM(__aeabi_ul2f);
 /* integer division */


### PR DESCRIPTION
## Summary

Sketches build as llext (dynamically-linked extensions) and can only link
against symbols the loader explicitly exports. `double` arithmetic is fully
covered (all `__aeabi_d*` helpers exported in both `loader/llext_exports.c`
and `cores/arduino/llext_wrappers.c`), but `float` (32-bit) was only
partially covered:

- Comparisons: only `fcmple`/`fcmpun` were exported (missing
  `fcmpeq`/`fcmplt`/`fcmpgt`/`fcmpge`)
- Conversions: only int64<->float (`l2f`/`ul2f`) were exported (missing
  int32<->float `i2f`/`ui2f`/`f2iz`/`f2uiz`)
- Arithmetic: `__aeabi_fadd`/`fsub`/`fmul`/`fdiv` were **missing entirely**

As a result, plain `float` arithmetic in a sketch (e.g. `float a = 1.0f + 2.0f;`)
fails to link with undefined reference errors, even though the equivalent
`double` code works fine.

This wasn't an intentional exclusion - `double` support was added reactively
in b32825c1 for a specific reported link error, and nobody has filed the
equivalent report for `float` since. This PR mirrors that same pattern for
the missing `float` helpers.

## Changes

- `loader/llext_exports.c`: add `EXPORT_AEABI_SYM` for the missing symbols
- `cores/arduino/llext_wrappers.c`: add matching `VN()` naked trampolines

## Testing

Compiled a sketch exercising float `+`, `-`, `*`, `/`, int<->float
conversion, and comparisons (`<`, `>`, `==`) on `frdm_mcxn947` - fails to
link on `main`, links and runs cleanly with this fix.