### PR TITLE
get_core_version: add 'g' before commit hash in version string

### DIFF
--- a/extra/get_core_version.sh
+++ b/extra/get_core_version.sh
@@ -40,7 +40,7 @@
 # tagged version. If there are no tags at all (for example when run in a fork
 # etc), it defaults to "9.9.9-<date-time>".
 #
-# Finally, non-exact-tag versions have a "+<commit-hash[-dirty]>" appended. The
+# Finally, non-exact-tag versions have a "+g<commit-hash[-dirty]>" appended. The
 # commit hash used is taken from HEAD_REF if set - this is to ensure that in CI
 # environments the correct commit is used, even in pull requests where HEAD
 # might be a temporary detached commit.
@@ -129,7 +129,7 @@ else
 
 		# If HEAD_REF is not set, we're not in CI but in a local clone. Use the
 		# implicit HEAD and include --dirty to test for uncommitted changes.
-		v_tweak="+$(git describe --always ${HEAD_REF:---dirty})"
+		v_tweak="+g$(git describe --always ${HEAD_REF:---dirty})"
 	fi
 fi
 


### PR DESCRIPTION
Zephyr does not accept a fully numeric version string, so add a `g` before the commit hash in the version string to make it non-numeric. The letter `g` is not a valid hex digit so it is easy to filter out if needed.