### PR TITLE
bootstrap: multi SDK support

### DIFF
--- a/.github/workflows/package_core.yml
+++ b/.github/workflows/package_core.yml
@@ -184,7 +184,8 @@ jobs:
           name: build-env.tar.zstd
 
       - name: Restore build environment
-        timeout-minutes: 2 # early error on Github network issues
+        id: restore-env
+        timeout-minutes: 3 # early error on Github network issues
         run: |
           sudo apt-get remove --purge man-db -y # skips the mandb triggers
           sudo apt-get update
@@ -236,7 +237,7 @@ jobs:
           echo "::endgroup::"
 
       - name: Package board artifacts
-        if: ${{ !cancelled() }}
+        if: ${{ steps.restore-env.outcome == 'success' && !cancelled() }}
         run: |
           # add the config file to the report files, list them for later archiving
           cp firmwares/zephyr-${{ matrix.variant }}.config $REPORT.config
@@ -255,7 +256,7 @@ jobs:
           | zstd > binaries-${ARTIFACT_TAG}.tar.zstd
 
       - name: Archive board binaries
-        if: ${{ !cancelled() }}
+        if: ${{ steps.restore-env.outcome == 'success' && !cancelled() }}
         uses: actions/upload-artifact@v7
         with:
           # prefix the name with 'failed-' if the build failed, so that it is not removed
@@ -265,7 +266,7 @@ jobs:
           archive: false
 
       - name: Archive build reports
-        if: ${{ !cancelled() }}
+        if: ${{ steps.restore-env.outcome == 'success' && !cancelled() }}
         uses: actions/upload-artifact@v7
         with:
           name: build-report-${{ env.ARTIFACT_TAG }}

--- a/boards.txt
+++ b/boards.txt
@@ -620,18 +620,12 @@ nano_connect.build.zephyr_args=
 nano_connect.build.zephyr_hals=hal_rpi_pico
 nano_connect.build.artifact=zephyr_main
 nano_connect.build.variant=arduino_nano_connect_rp2040
-nano_connect.build.mcu=cortex-m0plus
-nano_connect.build.fpu=
-nano_connect.build.architecture=cortex-m0plus
-nano_connect.compiler.zephyr.arch.define=
 
-nano_connect.build.float-abi=-mfloat-abi=soft
 nano_connect.build.extra_flags=
 nano_connect.build.postbuild.cmd="{tools.imgtool.path}/{tools.imgtool.cmd}" exit
 nano_connect.recipe.hooks.objcopy.postobjcopy.3.pattern="{runtime.tools.bin2uf2.path}/bin2uf2" {upload.address} {upload.familyid} "{build.path}/{build.project_name}.{upload.extension}" "{build.path}/{build.project_name}.{upload.extension}.uf2"
 nano_connect.upload.artifacts.sketch={build.path}/{build.project_name}.{upload.extension}.uf2
 nano_connect.build.board=NANO_RP2040_CONNECT
-nano_connect.compiler.zephyr=
 nano_connect.upload_port.0.vid=0x2341
 nano_connect.upload_port.0.pid=0x065E
 
@@ -642,10 +636,7 @@ nano_connect.upload.transport=
 nano_connect.upload.use_1200bps_touch=true
 nano_connect.upload.wait_for_upload_port=false
 nano_connect.upload.native_usb=true
-nano_connect.upload.maximum_size=16777216
-nano_connect.upload.maximum_data_size=270336
 
-nano_connect.upload.address=0x100E0000
 nano_connect.upload.familyid=0xe48bff56
 
 nano_connect.bootloader.tool=picotool

--- a/boards.txt
+++ b/boards.txt
@@ -39,6 +39,7 @@ giga.menu.link_mode.static.upload.extension=bin-zsk.bin
 giga.build.zephyr_target=arduino_giga_r1//m7
 giga.build.zephyr_args=--shield arduino_giga_display_shield
 giga.build.zephyr_hals=hal_stm32 hal_infineon
+giga.build.zephyr_toolchain=arm-zephyr-eabi
 giga.build.variant=arduino_giga_r1_stm32h747xx_m7
 giga.build.artifact=zephyr_main
 
@@ -90,6 +91,7 @@ nano33ble.menu.link_mode.static.upload.extension=bin-zsk.bin
 nano33ble.build.zephyr_target=arduino_nano_33_ble//sense
 nano33ble.build.zephyr_args=
 nano33ble.build.zephyr_hals=hal_nordic
+nano33ble.build.zephyr_toolchain=arm-zephyr-eabi
 nano33ble.build.artifact=zephyr_main
 nano33ble.build.variant=arduino_nano_33_ble_nrf52840_sense
 
@@ -138,6 +140,7 @@ ek_ra8d1.menu.link_mode.static.upload.extension=bin-zsk.bin
 ek_ra8d1.build.zephyr_target=ek_ra8d1
 ek_ra8d1.build.zephyr_args=
 ek_ra8d1.build.zephyr_hals=hal_renesas
+ek_ra8d1.build.zephyr_toolchain=arm-zephyr-eabi
 ek_ra8d1.build.variant=ek_ra8d1_r7fa8d1bhecbd
 
 ek_ra8d1.build.extra_flags=
@@ -184,6 +187,7 @@ frdm_mcxn947.menu.link_mode.static.upload.extension=bin-zsk.bin
 frdm_mcxn947.build.zephyr_target=frdm_mcxn947//cpu0
 frdm_mcxn947.build.zephyr_args=
 frdm_mcxn947.build.zephyr_hals=hal_nxp
+frdm_mcxn947.build.zephyr_toolchain=arm-zephyr-eabi
 frdm_mcxn947.build.variant=frdm_mcxn947_mcxn947_cpu0
 
 frdm_mcxn947.build.extra_flags=
@@ -226,6 +230,7 @@ portentah7.menu.link_mode.static.upload.extension=bin-zsk.bin
 portentah7.build.zephyr_target=arduino_portenta_h7@1.0.0//m7
 portentah7.build.zephyr_args=
 portentah7.build.zephyr_hals=hal_stm32 hal_infineon
+portentah7.build.zephyr_toolchain=arm-zephyr-eabi
 portentah7.build.artifact=zephyr_main
 portentah7.build.variant=arduino_portenta_h7_stm32h747xx_m7
 
@@ -277,6 +282,7 @@ nicla_vision.menu.link_mode.static.upload.extension=bin-zsk.bin
 nicla_vision.build.zephyr_target=arduino_nicla_vision//m7
 nicla_vision.build.zephyr_args=
 nicla_vision.build.zephyr_hals=hal_stm32 hal_infineon
+nicla_vision.build.zephyr_toolchain=arm-zephyr-eabi
 nicla_vision.build.artifact=zephyr_main
 nicla_vision.build.variant=arduino_nicla_vision_stm32h747xx_m7
 
@@ -328,6 +334,7 @@ frdm_rw612.menu.link_mode.static.upload.extension=bin-zsk.bin
 frdm_rw612.build.zephyr_target=frdm_rw612
 frdm_rw612.build.zephyr_args=
 frdm_rw612.build.zephyr_hals=hal_stm32
+frdm_rw612.build.zephyr_toolchain=arm-zephyr-eabi
 frdm_rw612.build.variant=frdm_rw612_rw612
 
 frdm_rw612.build.extra_flags=
@@ -365,6 +372,7 @@ nicla_sense.menu.link_mode.static.upload.extension=bin-zsk.bin
 nicla_sense.build.zephyr_target=arduino_nicla_sense_me
 nicla_sense.build.zephyr_args=
 nicla_sense.build.zephyr_hals=hal_nordic
+nicla_sense.build.zephyr_toolchain=arm-zephyr-eabi
 nicla_sense.build.artifact=zephyr_main
 nicla_sense.build.variant=arduino_nicla_sense_me_nrf52832
 
@@ -416,6 +424,7 @@ portentac33.menu.link_mode.static.upload.extension=bin-zsk.bin
 portentac33.build.zephyr_target=arduino_portenta_c33
 portentac33.build.zephyr_args=
 portentac33.build.zephyr_hals=hal_renesas nanopb
+portentac33.build.zephyr_toolchain=arm-zephyr-eabi
 portentac33.build.artifact=zephyr_main
 portentac33.build.variant=arduino_portenta_c33_r7fa6m5bh3cfc
 
@@ -466,6 +475,7 @@ opta.menu.link_mode.static.upload.extension=bin-zsk.bin
 opta.build.zephyr_target=arduino_opta//m7
 opta.build.zephyr_args=
 opta.build.zephyr_hals=hal_stm32 hal_infineon
+opta.build.zephyr_toolchain=arm-zephyr-eabi
 opta.build.artifact=zephyr_main
 opta.build.variant=arduino_opta_stm32h747xx_m7
 
@@ -513,6 +523,7 @@ nano_matter.menu.link_mode.static.upload.extension=bin-zsk.bin
 nano_matter.build.zephyr_target=arduino_nano_matter
 nano_matter.build.zephyr_args=
 nano_matter.build.zephyr_hals=hal_silabs
+nano_matter.build.zephyr_toolchain=arm-zephyr-eabi
 nano_matter.build.artifact=zephyr_main
 nano_matter.build.variant=arduino_nano_matter_mgm240sd22vna
 
@@ -571,6 +582,8 @@ unoq.menu.wait_linux_boot.app.build.boot_mode=app
 
 unoq.build.zephyr_target=arduino_uno_q
 unoq.build.zephyr_args=
+unoq.build.zephyr_hals=hal_stm32
+unoq.build.zephyr_toolchain=arm-zephyr-eabi
 unoq.build.variant=arduino_uno_q_stm32u585xx
 unoq.build.artifact=zephyr_unoq
 unoq.build.subarch=zephyr
@@ -579,8 +592,6 @@ unoq.openocd_cfg=flash_sketch.cfg
 unoq.build.extra_flags=
 unoq.build.postbuild.cmd="{tools.imgtool.path}/{tools.imgtool.cmd}" exit
 unoq.build.board=UNO_Q
-unoq.build.zephyr_hals=hal_stm32
-unoq.build.zephyr_toolchain=arm-zephyr-eabi
 unoq.upload_port.0.vid=0x2341
 unoq.upload_port.0.pid=0x0078
 unoq.upload.target=stm32u585zitxq
@@ -618,6 +629,7 @@ nano_connect.menu.link_mode.static.upload.extension=bin-zsk.bin
 nano_connect.build.zephyr_target=arduino_nano_connect
 nano_connect.build.zephyr_args=
 nano_connect.build.zephyr_hals=hal_rpi_pico
+nano_connect.build.zephyr_toolchain=arm-zephyr-eabi
 nano_connect.build.artifact=zephyr_main
 nano_connect.build.variant=arduino_nano_connect_rp2040
 

--- a/extra/bootstrap.sh
+++ b/extra/bootstrap.sh
@@ -40,7 +40,13 @@ pip install west protobuf grpcio-tools
 log_msg "endgroup"
 
 log_msg "group" "Initializing Zephyr workspace and modules: $HAL_FILTER"
-west init -l .
+if ! [ -d ../.west ] ; then
+  log_msg "group" "Initializing Zephyr workspace and modules: $HAL_FILTER"
+  west init -l .
+else
+  log_msg "warning" "Zephyr workspace already initialized, skipping west init"
+  log_msg "group" "Refreshing workspace and modules: $HAL_FILTER"
+fi
 west config manifest.project-filter -- "$HAL_FILTER"
 west update "$@"
 west zephyr-export

--- a/extra/bootstrap.sh
+++ b/extra/bootstrap.sh
@@ -4,9 +4,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 set -e
+set -o pipefail
 
 log_msg() {
-	if [ -n $GITHUB_WORKSPACE ] ; then
+	if [ -n "$GITHUB_WORKSPACE" ] ; then
 		echo "::$1::$2"
 	else
 		echo " - $2"
@@ -18,7 +19,14 @@ if [ ! -f platform.txt ]; then
   exit 2
 fi
 
-NEEDED_HALS=$(grep 'build.zephyr_hals=' boards.txt | cut -d '=' -f 2 | xargs -n 1 echo | sort -u | xargs echo)
+get_unique_field_values() {
+  local field="$1"
+  local file="$2"
+  grep "$field=" $file | cut -d '=' -f 2 | xargs -n 1 echo | sort -u | xargs echo
+}
+
+NEEDED_HALS=$(get_unique_field_values 'build.zephyr_hals' boards.txt)
+NEEDED_TOOLCHAINS=$(get_unique_field_values 'build.zephyr_toolchain' boards.txt)
 
 HAL_FILTER="-hal_.*"
 for hal in $NEEDED_HALS; do
@@ -39,9 +47,21 @@ west zephyr-export
 pip install -r ../zephyr/scripts/requirements-base.txt
 log_msg "endgroup"
 
-log_msg "group" "Installing Zephyr SDK 0.16.8"
-west sdk install --version 0.16.8 -t arm-zephyr-eabi
-log_msg "endgroup"
+TOOLCHAIN_VERSIONS=$(for tc in $NEEDED_TOOLCHAINS; do
+  version=$(jq -r --arg name "$tc" '.toolsDependencies[] | select(.name == $name) | .version' extra/artifacts/_common.json)
+  if [ -z "$version" ]; then
+    echo "No version found for toolchain '$tc' in extra/artifacts/_common.json" >&2
+    exit 1
+  fi
+  echo "$version $tc"
+done | sort -V)
+
+for version in $(echo "$TOOLCHAIN_VERSIONS" | cut -d ' ' -f 1 | sort -u -V); do
+  toolchains=$(echo "$TOOLCHAIN_VERSIONS" | awk -v v="$version" '$1 == v { print $2 }')
+  log_msg "group" "Installing Zephyr SDK ${version}: ${toolchains}"
+  west sdk install --version "$version" -t $toolchains
+  log_msg "endgroup"
+done
 
 log_msg "group" "Fetching blobs for: $NEEDED_HALS"
 west blobs fetch $NEEDED_HALS

--- a/extra/bootstrap.sh
+++ b/extra/bootstrap.sh
@@ -19,6 +19,19 @@ if [ ! -f platform.txt ]; then
   exit 2
 fi
 
+REQUIRED_TOOLS="cmake curl git jq ninja pip3 python3 wget zip"
+MISSING_TOOLS=""
+for tool in $REQUIRED_TOOLS; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    MISSING_TOOLS="$MISSING_TOOLS $tool"
+  fi
+done
+if [ -n "$MISSING_TOOLS" ]; then
+  echo "Missing required tools:$MISSING_TOOLS" >&2
+  echo "Install them before running this script." >&2
+  exit 2
+fi
+
 get_unique_field_values() {
   local field="$1"
   local file="$2"
@@ -36,7 +49,7 @@ done
 log_msg "group" "Bootstrapping Python environment for Zephyr"
 python3 -m venv venv
 source venv/bin/activate
-pip install west protobuf grpcio-tools
+pip3 install west protobuf grpcio-tools
 log_msg "endgroup"
 
 log_msg "group" "Initializing Zephyr workspace and modules: $HAL_FILTER"
@@ -50,7 +63,7 @@ fi
 west config manifest.project-filter -- "$HAL_FILTER"
 west update "$@"
 west zephyr-export
-pip install -r ../zephyr/scripts/requirements-base.txt
+pip3 install -r ../zephyr/scripts/requirements-base.txt
 log_msg "endgroup"
 
 TOOLCHAIN_VERSIONS=$(for tc in $NEEDED_TOOLCHAINS; do


### PR DESCRIPTION
* Allow specifying per-board toolchain to enable non-ARM targets. 
* The SDK version is automatically detected per-toolchain by `bootstrap.sh` from the JSON template. 
* Fix bootstrap.sh to cleanly update the existing worksapce when re-run on local installs.