### PR TITLE
frdm_mcxn947: add NXP LinkServer upload support (auto-selected when installed)

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -193,16 +193,16 @@ frdm_mcxn947.upload_port.0.vid=0x1fc9
 frdm_mcxn947.upload_port.0.pid=0x0143
 frdm_mcxn947.upload.target=mcxn947vdf
 
-frdm_mcxn947.upload.tool=pyocd
-frdm_mcxn947.upload.tool.default=pyocd
+frdm_mcxn947.upload.tool=mcxn947_auto
+frdm_mcxn947.upload.tool.default=mcxn947_auto
 frdm_mcxn947.upload.protocol=
 frdm_mcxn947.upload.transport=
 frdm_mcxn947.upload.use_1200bps_touch=false
 frdm_mcxn947.upload.wait_for_upload_port=false
 frdm_mcxn947.upload.native_usb=true
 
-frdm_mcxn947.bootloader.tool=pyocd
-frdm_mcxn947.bootloader.tool.default=pyocd
+frdm_mcxn947.bootloader.tool=mcxn947_auto
+frdm_mcxn947.bootloader.tool.default=mcxn947_auto
 frdm_mcxn947.bootloader.file=zephyr-{build.variant}.elf
 frdm_mcxn947.bootloader.target=mcxn947vdf
 

--- a/boards.txt
+++ b/boards.txt
@@ -192,6 +192,9 @@ frdm_mcxn947.build.board=FRDM_MCXN947
 frdm_mcxn947.upload_port.0.vid=0x1fc9
 frdm_mcxn947.upload_port.0.pid=0x0143
 frdm_mcxn947.upload.target=mcxn947vdf
+frdm_mcxn947.upload.address=0x100f0000
+frdm_mcxn947.upload.maximum_size=57344
+frdm_mcxn947.upload.maximum_data_size=32768
 
 frdm_mcxn947.upload.tool=mcxn947_auto
 frdm_mcxn947.upload.tool.default=mcxn947_auto

--- a/platform.txt
+++ b/platform.txt
@@ -328,6 +328,24 @@ tools.pyocd.bootloader.pattern="{cmd}" load --target {bootloader.target} "{uploa
 
 
 #
+# MCXN947 AUTO WRAPPER (LinkServer if installed, otherwise pyocd)
+#
+# Used only by frdm_mcxn947. NXP LinkServer is not redistributable via the
+# Arduino tool index, so it must be installed separately by the user; if
+# found, it is used in place of pyocd, which otherwise remains the default.
+
+tools.mcxn947_auto.upload.params.verbose=
+tools.mcxn947_auto.upload.params.quiet=
+tools.mcxn947_auto.upload.pattern="{runtime.platform.path}/tools/upload_pyocd_or_linkserver.sh" "{upload.artifacts.sketch}" "{upload.target}" "{upload.address}"
+tools.mcxn947_auto.upload.pattern.windows="{runtime.platform.path}/tools/upload_pyocd_or_linkserver.bat" "{upload.artifacts.sketch}" "{upload.target}" "{upload.address}"
+
+tools.mcxn947_auto.bootloader.params.verbose=
+tools.mcxn947_auto.bootloader.params.quiet=
+tools.mcxn947_auto.bootloader.pattern="{runtime.platform.path}/tools/upload_pyocd_or_linkserver.sh" "{upload.artifacts.loader}" "{bootloader.target}" ""
+tools.mcxn947_auto.bootloader.pattern.windows="{runtime.platform.path}/tools/upload_pyocd_or_linkserver.bat" "{upload.artifacts.loader}" "{bootloader.target}" ""
+
+
+#
 # JLinkExe WRAPPER
 #
 

--- a/tools/upload_linkserver.bat
+++ b/tools/upload_linkserver.bat
@@ -1,4 +1,7 @@
 @echo off
+REM Copyright (c) Arduino s.r.l. and/or its affiliated companies
+REM SPDX-License-Identifier: Apache-2.0
+
 setlocal enabledelayedexpansion
 
 set "ELF=%~1"

--- a/tools/upload_linkserver.bat
+++ b/tools/upload_linkserver.bat
@@ -1,0 +1,34 @@
+@echo off
+setlocal enabledelayedexpansion
+
+set "ELF=%~1"
+set "ADDR=%~2"
+set "LINKSERVER="
+
+for /f "delims=" %%D in ('dir /b /ad /o-n "C:\nxp\LinkServer_*" 2^>nul') do (
+    if not defined LINKSERVER (
+        if exist "C:\nxp\%%D\LinkServer.exe" (
+            set "LINKSERVER=C:\nxp\%%D\LinkServer.exe"
+        )
+    )
+)
+
+if not defined LINKSERVER (
+    where LinkServer.exe >nul 2>nul
+    if !errorlevel! == 0 (
+        set "LINKSERVER=LinkServer.exe"
+    )
+)
+
+if not defined LINKSERVER (
+    echo ERROR: LinkServer not found.
+    exit /b 1
+)
+
+echo Using: !LINKSERVER!
+
+if not "%ADDR%"=="" (
+    "%LINKSERVER%" flash MCXN947:FRDM-MCXN947 load "%ELF%:%ADDR%"
+) else (
+    "%LINKSERVER%" flash MCXN947:FRDM-MCXN947 load "%ELF%"
+)

--- a/tools/upload_linkserver.sh
+++ b/tools/upload_linkserver.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+ELF="$1"
+ADDR="$2"
+
+LINKSERVER=""
+if [ "$(uname)" = "Darwin" ]; then
+    LINKSERVER_DIR=$(ls /Applications/ | grep "^LinkServer" | sort -V | tail -1)
+    if [ -n "$LINKSERVER_DIR" ]; then
+        LINKSERVER="/Applications/$LINKSERVER_DIR/LinkServer"
+    fi
+fi
+
+if [ -z "$LINKSERVER" ] || [ ! -f "$LINKSERVER" ]; then
+    echo "ERROR: LinkServer not found."
+    exit 1
+fi
+
+echo "Using: $LINKSERVER"
+
+if [ -n "$ADDR" ]; then
+    "$LINKSERVER" flash MCXN947:FRDM-MCXN947 load "$ELF:$ADDR"
+else
+    "$LINKSERVER" flash MCXN947:FRDM-MCXN947 load "$ELF"
+fi

--- a/tools/upload_linkserver.sh
+++ b/tools/upload_linkserver.sh
@@ -1,4 +1,8 @@
 #!/bin/sh
+
+# Copyright (c) Arduino s.r.l. and/or its affiliated companies
+# SPDX-License-Identifier: Apache-2.0
+
 ELF="$1"
 ADDR="$2"
 

--- a/tools/upload_linkserver.sh
+++ b/tools/upload_linkserver.sh
@@ -8,9 +8,22 @@ if [ "$(uname)" = "Darwin" ]; then
     if [ -n "$LINKSERVER_DIR" ]; then
         LINKSERVER="/Applications/$LINKSERVER_DIR/LinkServer"
     fi
+elif [ "$(uname)" = "Linux" ]; then
+    if [ -x /usr/local/LinkServer/LinkServer ]; then
+        LINKSERVER=/usr/local/LinkServer/LinkServer
+    else
+        LINKSERVER_DIR=$(ls -d /usr/local/LinkServer_* 2>/dev/null | sort -V | tail -1)
+        if [ -n "$LINKSERVER_DIR" ]; then
+            LINKSERVER="$LINKSERVER_DIR/LinkServer"
+        fi
+    fi
 fi
 
-if [ -z "$LINKSERVER" ] || [ ! -f "$LINKSERVER" ]; then
+if [ -z "$LINKSERVER" ] || [ ! -x "$LINKSERVER" ]; then
+    LINKSERVER=$(command -v LinkServer 2>/dev/null)
+fi
+
+if [ -z "$LINKSERVER" ] || [ ! -x "$LINKSERVER" ]; then
     echo "ERROR: LinkServer not found."
     exit 1
 fi

--- a/tools/upload_pyocd_or_linkserver.bat
+++ b/tools/upload_pyocd_or_linkserver.bat
@@ -1,4 +1,7 @@
 @echo off
+REM Copyright (c) Arduino s.r.l. and/or its affiliated companies
+REM SPDX-License-Identifier: Apache-2.0
+
 setlocal enabledelayedexpansion
 
 set "ELF=%~1"

--- a/tools/upload_pyocd_or_linkserver.bat
+++ b/tools/upload_pyocd_or_linkserver.bat
@@ -1,0 +1,40 @@
+@echo off
+setlocal enabledelayedexpansion
+
+set "ELF=%~1"
+set "TARGET=%~2"
+set "ADDR=%~3"
+set "LINKSERVER="
+
+for /f "delims=" %%D in ('dir /b /ad /o-n "C:\nxp\LinkServer_*" 2^>nul') do (
+    if not defined LINKSERVER (
+        if exist "C:\nxp\%%D\LinkServer.exe" (
+            set "LINKSERVER=C:\nxp\%%D\LinkServer.exe"
+        )
+    )
+)
+
+if not defined LINKSERVER (
+    where LinkServer.exe >nul 2>nul
+    if !errorlevel! == 0 (
+        set "LINKSERVER=LinkServer.exe"
+    )
+)
+
+if defined LINKSERVER (
+    echo LinkServer found, using: !LINKSERVER!
+    if not "%ADDR%"=="" (
+        "%LINKSERVER%" flash MCXN947:FRDM-MCXN947 load "%ELF%:%ADDR%"
+    ) else (
+        "%LINKSERVER%" flash MCXN947:FRDM-MCXN947 load "%ELF%"
+    )
+    exit /b %errorlevel%
+)
+
+echo LinkServer not found, using: pyocd
+if not "%ADDR%"=="" (
+    pyocd load --target %TARGET% "%ELF%@%ADDR%"
+) else (
+    pyocd load --target %TARGET% "%ELF%"
+)
+exit /b %errorlevel%

--- a/tools/upload_pyocd_or_linkserver.sh
+++ b/tools/upload_pyocd_or_linkserver.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+ELF="$1"
+TARGET="$2"
+ADDR="$3"
+
+LINKSERVER=""
+if [ "$(uname)" = "Darwin" ]; then
+    LINKSERVER_DIR=$(ls /Applications/ | grep "^LinkServer" | sort -V | tail -1)
+    if [ -n "$LINKSERVER_DIR" ]; then
+        LINKSERVER="/Applications/$LINKSERVER_DIR/LinkServer"
+    fi
+elif [ "$(uname)" = "Linux" ]; then
+    if [ -x /usr/local/LinkServer/LinkServer ]; then
+        LINKSERVER=/usr/local/LinkServer/LinkServer
+    else
+        LINKSERVER_DIR=$(ls -d /usr/local/LinkServer_* 2>/dev/null | sort -V | tail -1)
+        if [ -n "$LINKSERVER_DIR" ]; then
+            LINKSERVER="$LINKSERVER_DIR/LinkServer"
+        fi
+    fi
+fi
+
+if [ -z "$LINKSERVER" ] || [ ! -x "$LINKSERVER" ]; then
+    LINKSERVER=$(command -v LinkServer 2>/dev/null)
+fi
+
+if [ -n "$LINKSERVER" ] && [ -x "$LINKSERVER" ]; then
+    echo "LinkServer found, using: $LINKSERVER"
+    if [ -n "$ADDR" ]; then
+        exec "$LINKSERVER" flash MCXN947:FRDM-MCXN947 load "$ELF:$ADDR"
+    else
+        exec "$LINKSERVER" flash MCXN947:FRDM-MCXN947 load "$ELF"
+    fi
+fi
+
+echo "LinkServer not found, using: pyocd"
+if [ -n "$ADDR" ]; then
+    exec pyocd load --target "$TARGET" "$ELF@$ADDR"
+else
+    exec pyocd load --target "$TARGET" "$ELF"
+fi

--- a/tools/upload_pyocd_or_linkserver.sh
+++ b/tools/upload_pyocd_or_linkserver.sh
@@ -1,4 +1,8 @@
 #!/bin/sh
+
+# Copyright (c) Arduino s.r.l. and/or its affiliated companies
+# SPDX-License-Identifier: Apache-2.0
+
 ELF="$1"
 TARGET="$2"
 ADDR="$3"


### PR DESCRIPTION
## Summary

Adds NXP LinkServer as an upload/flash option for FRDM-MCXN947, in addition to the existing `pyocd` support.

- `tools/upload_linkserver.sh` / `.bat`: locate an installed LinkServer (macOS `/Applications`, Linux `/usr/local/LinkServer*`, Windows `C:\nxp\LinkServer_*`, with a `PATH` fallback on all three) and flash a given ELF/address via `LinkServer flash MCXN947:FRDM-MCXN947 load ...`.
- New `mcxn947_auto` tool (`platform.txt`) used only by `frdm_mcxn947`: at upload time, it uses LinkServer if found, otherwise falls back to `pyocd` (the previous default). No menu, no user interaction required - existing users without LinkServer installed see no change in behavior.
- `boards.txt`: `frdm_mcxn947.upload.tool`/`bootloader.tool` switched from `pyocd` to `mcxn947_auto`; also adds `upload.address`/`upload.maximum_size`/`upload.maximum_data_size` directly (matching the values the release packaging step already bakes in - see note below), so the board works out of the box without requiring `boards.local.txt` to be generated first via `extra/build.sh`.

## Why

LinkServer is NXP's own supported programming tool for MCX parts and is already a common install for people working with NXP hardware/MCUXpresso. It's not redistributable via the Arduino tool index (proprietary, installed separately by the user), so this follows the same "detect a separately-installed tool" pattern used elsewhere for similar vendor tools (e.g. Segger J-Link on other cores) rather than attempting to bundle it.

## Note on `boards.txt`

This file has an existing comment stating `upload.address`/`upload.maximum_size`/`upload.maximum_data_size` "will have no effect" because they're normally generated into the gitignored `boards.local.txt` by `extra/build.sh`. That's true for the dev workflow (`boards.local.txt` always overrides these when present), but the installed release package does *not* ship a `boards.local.txt` - the release packaging step bakes these same values directly into the shipped `boards.txt` instead (verified against the currently installed 0.90.0 release). Adding them here matches that release-time behavior and lets a plain checkout of this branch compile+upload without running `extra/build.sh` first.

## Testing

Verified end-to-end (compile + real hardware flash to a FRDM-MCXN947) on all three OSes:
- macOS: via Arduino IDE (`arduino-git:zephyr` dev package) and via `arduino-cli`, with `boards.local.txt`/`platform.local.txt` both absent.
- Windows: via Arduino IDE, LinkServer auto-detected and used.
- Linux: via Arduino IDE, LinkServer auto-detected and used.

Also verified the fallback path: without LinkServer installed, `frdm_mcxn947.upload.tool=mcxn947_auto` resolves to `pyocd`, matching prior behavior.