### PR TITLE
overlay: portentah7: match mbed Serial pin mapping, add UART7/UART8

### DIFF
--- a/variants/arduino_portenta_h7_stm32h747xx_m7/arduino_portenta_h7_stm32h747xx_m7.overlay
+++ b/variants/arduino_portenta_h7_stm32h747xx_m7/arduino_portenta_h7_stm32h747xx_m7.overlay
@@ -10,7 +10,7 @@
 
 &usart1 {
 	status = "okay";
-	zephyr,deferred-init;
+	/* usart1 is not set as deferred-init to catch early boot logs since it is assigned to zephyr,console */
 };
 
 &uart4 {
@@ -20,7 +20,12 @@
 
 &usart6 {
 	status = "okay";
-	/* usart6 is not set as deferred-init to catch early boot logs since it is assigned to zephyr,console */
+	zephyr,deferred-init;
+};
+
+&uart8 {
+	status = "okay";
+	zephyr,deferred-init;
 };
 
 &rtc {
@@ -295,9 +300,9 @@
 		zephyr,camera = &dcmi;
 		zephyr,display = &ltdc;
 		zephyr,mipi-dsi = &mipi_dsi;
-		zephyr,console = &usart6;
-		zephyr,shell-uart = &usart6;
-		zephyr,cdc-acm-uart0 = &usart6;
+		zephyr,console = &usart1;
+		zephyr,shell-uart = &usart1;
+		zephyr,cdc-acm-uart0 = &usart1;
 		zephyr,log-uart = &log_uarts;
 		arduino,camera-clock = &pwmclock;
 		arduino,eth-clock = &pwmclock;
@@ -305,7 +310,7 @@
 
 	log_uarts: log_uarts {
 		compatible = "zephyr,log-uart";
-		uarts = <&usart6 &board_cdc_acm_uart>;
+		uarts = <&usart1 &board_cdc_acm_uart>;
 	};
 
 	/* used to overcome problems with _C analog pins */
@@ -445,7 +450,7 @@ qspi_flash: &mx25l12833f {};
 				<&gpio_invalid 5 0>;			/* Hack for D20 */
 
 		cdc-acm-serial = <&board_cdc_acm_uart>; /* 'Serial' object is managed by SerialUSB */
-		serials = <&usart6>, <&usart1>, <&uart4>; /* 'Serial1' onwards */
+		serials = <&usart1>, <&uart7>, <&uart8>, <&usart6>, <&uart4>; /* 'Serial1' onwards */
 		i2cs = <&i2c3>, <&i2c1>, <&i2c4>;
 		spis = <&spi2>;
 		cans = <&fdcan1>;


### PR DESCRIPTION
Reorder the Arduino serials so Serial1..Serial3 match the mbed core pin mapping, enable UART8 (deferred-init) and move the console to USART1. UART7 stays bound to the Murata 1DX Bluetooth HCI, so Serial2 and CONFIG_BT remain mutually exclusive (same behaviour as the mbed core).

```
Serial  | Zephyr node | TX   | RX   | RTS | CTS | Notes
--------+-------------+------+------+-----+-----+---------------------------
Serial  | cdc_acm     | -    | -    | -   | -   | USB CDC (SerialUSB)
Serial1 | usart1      | PA9  | PA10 | -   | -   | console / shell
Serial2 | uart7       | PA15 | PF6  | PF8 | PF9 | Bluetooth HCI (Murata 1DX)
Serial3 | uart8       | PJ8  | PJ9  | -   | -   |
Serial4 | usart6      | PG14 | PG9  | -   | -   |
Serial5 | uart4       | PA0  | PI9  | -   | -   |
```