### PR TITLE
get_core_version: use lowercase letters in timestamp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /venv/
 /boards.local.txt
 /platform.local.txt
+/loader/VERSION
 
 llext-edk/
 cflags.txt

--- a/extra/get_core_version.sh
+++ b/extra/get_core_version.sh
@@ -49,7 +49,7 @@
 # VERSION format if a filename is provided as the first argument.
 
 # Determine pre-release label based on build context
-DATE="$(date -u '+%y%m%dT%H%MZ')"
+DATE="$(date -u '+%y%m%dt%H%Mz')"
 if [ -z "$GITHUB_ACTIONS" ]; then
 	# local build, highest precedence
 	KIND="wip"


### PR DESCRIPTION
Switch to lowercase letters in the timestamp format to avoid issues with Zephyr ignoring uppercase letters in the version string.