### PR TITLE
platform: add `{sketch.with/without_loader}` options to fix c33 upload

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -443,7 +443,7 @@ portentac33.upload.interface=1
 portentac33.upload.use_1200bps_touch=true
 portentac33.upload.wait_for_upload_port=false
 portentac33.upload.native_usb=true
-portentac33.upload.dfuse=-w
+portentac33.upload.dfuse=
 
 portentac33.bootloader.tool=dfu-util
 portentac33.bootloader.tool.default=dfu-util
@@ -453,8 +453,10 @@ portentac33.bootloader.address=0x10000
 portentac33.bootloader.pid=0x0368
 portentac33.bootloader.dfuse=
 
-# the space before -Q is important
+# the space before the extra arguments is important
 portentac33.leave.dfuse={empty} -Q
+portentac33.loader.args.with_sketch={empty} -w
+portentac33.sketch.args.without_loader={empty} -w
 
 ##########################################################################################
 

--- a/platform.txt
+++ b/platform.txt
@@ -180,15 +180,18 @@ upload.artifacts.sketch={build.path}/{build.project_name}.{upload.extension}
 # Expects a {loader.cmd} and a {sketch.cmd} to be defined in the tool's
 # section. The loader is flashed if it does not match the current (maybe
 # board-specific) core version. The sketch is then flashed in any case.
-# Extra arguments are passed to the loader command depending on whether
-# the sketch will be flashed in the same session or not.
+# Extra arguments are passed to either command depending on whether the other
+# part will be flashed in the same session or not.
 empty=
 loader.args.with_sketch={empty}
 loader.args.without_sketch={empty}
+sketch.args.with_loader={empty}
+sketch.args.without_loader={empty}
 flash-loader-condition=not eq "v{upload.port.properties.configuration}" "v{version}"
 flash-loader-and-sketch.1=if {flash-loader-condition} {loader.cmd}{loader.args.with_sketch}
-flash-loader-and-sketch.2=run {sketch.cmd}
-tools.patterns.flash-loader-and-sketch="{runtime.tools.scripting-tools.path}/scripting-tools" {flash-loader-and-sketch.1} :: {flash-loader-and-sketch.2}
+flash-loader-and-sketch.2=if {flash-loader-condition} {sketch.cmd}{sketch.args.with_loader}
+flash-loader-and-sketch.3=if not {flash-loader-condition} {sketch.cmd}{sketch.args.without_loader}
+tools.patterns.flash-loader-and-sketch="{runtime.tools.scripting-tools.path}/scripting-tools" {flash-loader-and-sketch.1} :: {flash-loader-and-sketch.2} :: {flash-loader-and-sketch.3}
 tools.patterns.flash-loader-only={loader.cmd}{loader.args.without_sketch}
 
 #

--- a/platform.txt
+++ b/platform.txt
@@ -185,7 +185,10 @@ upload.artifacts.sketch={build.path}/{build.project_name}.{upload.extension}
 empty=
 loader.args.with_sketch={empty}
 loader.args.without_sketch={empty}
-tools.patterns.flash-loader-and-sketch="{runtime.tools.scripting-tools.path}/scripting-tools" if not eq "v{upload.port.properties.configuration}" "v{version}" {loader.cmd}{loader.args.with_sketch} :: run {sketch.cmd}
+flash-loader-condition=not eq "v{upload.port.properties.configuration}" "v{version}"
+flash-loader-and-sketch.1=if {flash-loader-condition} {loader.cmd}{loader.args.with_sketch}
+flash-loader-and-sketch.2=run {sketch.cmd}
+tools.patterns.flash-loader-and-sketch="{runtime.tools.scripting-tools.path}/scripting-tools" {flash-loader-and-sketch.1} :: {flash-loader-and-sketch.2}
 tools.patterns.flash-loader-only={loader.cmd}{loader.args.without_sketch}
 
 #


### PR DESCRIPTION
Refactor current scripting-tools invocation to provide step-specific flags to both the loader and sketch. This means that additional options are added to the command line of either tool depending on whether the other step executed or not. 

This is required in the Portenta C33 case because after a 1200 touch, the first dfu-tool invocation should wait for OS detection of the bootloader; the second one should not, to avoid waiting until timeout. By providing all possible commands, the scripting tool will run the appropriate ones and `-w` will be added where appropriate.

  