### PR TITLE
dependabot: fix CI rules for branches

### DIFF
--- a/.github/workflows/commit_check.yml
+++ b/.github/workflows/commit_check.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           pattern: '^[^!]+: [A-Za-z]+.+ .+$'
           flags: 'gm'
-          error: 'Commit subject line must match the following pattern: <scope>: <description>'
+          error: 'Commit subject line / PR title must match the following pattern: <scope>: <description>'
           excludeTitle: 'false'
           excludeDescription: 'true'
           checkAllCommitMessages: 'true'
@@ -29,7 +29,7 @@ jobs:
         with:
           pattern: '^[^#].{10,80}$'
           error: 'Commit subject line maximum line length of 80 characters is exceeded.'
-          excludeTitle: 'false'
+          excludeTitle: 'true'
           excludeDescription: 'true'
           checkAllCommitMessages: 'true'
           accessToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package_core.yml
+++ b/.github/workflows/package_core.yml
@@ -673,7 +673,7 @@ jobs:
   publish-core:
     name: Publish core
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' && github.repository == 'arduino/ArduinoCore-zephyr' }}
+    if: ${{ github.event_name == 'push' && github.repository == 'arduino/ArduinoCore-zephyr' && !startsWith(github.ref_name, 'dependabot/') }}
     needs:
       - build-env
       - package-core
@@ -767,7 +767,7 @@ jobs:
 
   ci-builds-upload:
     name: Upload to ci-builds
-    if: ${{ github.event_name == 'push' && github.repository == 'arduino/ArduinoCore-zephyr' }}
+    if: ${{ github.event_name == 'push' && github.repository == 'arduino/ArduinoCore-zephyr' && !startsWith(github.ref_name, 'dependabot/') }}
     runs-on: ubuntu-latest
     needs:
       - build-env


### PR DESCRIPTION
- allow PR titles to exceed 80 chars
- clarify "commit subject" also applies to PR title
- do not try to publish or track dependabot branches