### PR TITLE
artifacts: bump to use newest tools

### DIFF
--- a/extra/artifacts/_common.json
+++ b/extra/artifacts/_common.json
@@ -31,12 +31,12 @@
     {
       "packager": "arduino",
       "name": "zephyr-sketch-tool",
-      "version": "0.4.0"
+      "version": "0.4.1"
     },
     {
       "packager": "arduino",
       "name": "sync-zephyr-artifacts",
-      "version": "0.2.1"
+      "version": "0.2.2"
     },
     {
       "packager": "arduino",


### PR DESCRIPTION
Rebuild after dependabot updates:

- sync-zephyr-artifacts to 0.2.2
- zephyr-sketch-tool to 0.4.1