### PR TITLE
ci: cache west blobs downloads in package_core workflow

### DIFF
--- a/.github/workflows/package_core.yml
+++ b/.github/workflows/package_core.yml
@@ -95,8 +95,18 @@ jobs:
           echo "ARTIFACTS=$(jq -c '["zephyr"] + (map(.artifact) | unique)' <<< ${ALL_BOARD_DATA})" >> "$GITHUB_ENV"
           echo "SUB_ARCHES=$(jq -c 'map(.subarch) | unique' <<< ${ALL_BOARD_DATA})" >> "$GITHUB_ENV"
 
+      - name: Cache west modules and blobs
+        uses: actions/cache@v5
+        with:
+          key: west-cache-${{ hashFiles('west.yml', 'boards.txt') }}
+          restore-keys: |
+            west-blobs-
+          path: ${{ runner.temp }}/west-cache
+
       - name: Initialize Zephyr environment
         timeout-minutes: 10 # early error on Github network issues
+        env:
+          WEST_CACHE: ${{ runner.temp }}/west-cache
         run: |
           # Install Zephyr as a core user would, but faster
           yes | ./extra/bootstrap.sh -o=--filter=tree:0

--- a/.github/workflows/package_core.yml
+++ b/.github/workflows/package_core.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Install OS dependencies
         working-directory: /opt
-        timeout-minutes: 2 # early error on Github network issues
+        timeout-minutes: 5 # early error on Github network issues
         run: |
           sudo apt-get remove --purge man-db -y # skips the mandb triggers
           sudo apt-get update
@@ -96,7 +96,7 @@ jobs:
           echo "SUB_ARCHES=$(jq -c 'map(.subarch) | unique' <<< ${ALL_BOARD_DATA})" >> "$GITHUB_ENV"
 
       - name: Initialize Zephyr environment
-        timeout-minutes: 5 # early error on Github network issues
+        timeout-minutes: 10 # early error on Github network issues
         run: |
           # Install Zephyr as a core user would, but faster
           yes | ./extra/bootstrap.sh -o=--filter=tree:0
@@ -168,14 +168,14 @@ jobs:
     steps:
 
       - uses: actions/download-artifact@v8
-        timeout-minutes: 5 # early error on Github network issues
+        timeout-minutes: 10 # early error on Github network issues
         with:
           path: /home/runner
           name: build-env.tar.zstd
 
       - name: Restore build environment
         id: restore-env
-        timeout-minutes: 3 # early error on Github network issues
+        timeout-minutes: 5 # early error on Github network issues
         run: |
           sudo apt-get remove --purge man-db -y # skips the mandb triggers
           sudo apt-get update

--- a/extra/bootstrap.sh
+++ b/extra/bootstrap.sh
@@ -32,6 +32,13 @@ if [ -n "$MISSING_TOOLS" ]; then
   exit 2
 fi
 
+if [ -n "$WEST_CACHE" ]; then
+  # Set in CI context, uses a shared cache for west blobs and modules
+  mkdir -p $WEST_CACHE/blobs $WEST_CACHE/modules
+  WEST_BLOBS_CACHE="--cache-dirs $WEST_CACHE/blobs --auto-cache $WEST_CACHE/blobs"
+  WEST_MODULES_CACHE="--auto-cache $WEST_CACHE/modules"
+fi
+
 get_unique_field_values() {
   local field="$1"
   local file="$2"
@@ -52,7 +59,6 @@ source venv/bin/activate
 pip3 install west protobuf grpcio-tools
 log_msg "endgroup"
 
-log_msg "group" "Initializing Zephyr workspace and modules: $HAL_FILTER"
 if ! [ -d ../.west ] ; then
   log_msg "group" "Initializing Zephyr workspace and modules: $HAL_FILTER"
   west init -l .
@@ -61,7 +67,7 @@ else
   log_msg "group" "Refreshing workspace and modules: $HAL_FILTER"
 fi
 west config manifest.project-filter -- "$HAL_FILTER"
-west update "$@"
+west update $WEST_MODULES_CACHE "$@"
 west zephyr-export
 pip3 install -r ../zephyr/scripts/requirements-base.txt
 log_msg "endgroup"
@@ -84,5 +90,5 @@ done
 
 NEEDED_HALS="arduino-api $NEEDED_HALS"
 log_msg "group" "Fetching blobs for: $NEEDED_HALS"
-west blobs fetch $NEEDED_HALS
+west blobs $WEST_BLOBS_CACHE fetch $NEEDED_HALS
 log_msg "endgroup"


### PR DESCRIPTION
`west blobs fetch` re-downloads all HAL/API blobs on every CI run, which is slow and prone to transient network errors. Wire `west`'s built-in `--cache-dirs`/`--auto-cache` support into a GitHub Actions cache, keyed on `west.yml`/`boards.txt` so it stays stable across unrelated PRs.