### PR TITLE
zephyrSerial: add support for looking up SerialUSB in DT macros

### DIFF
--- a/cores/arduino/SerialUSB.h
+++ b/cores/arduino/SerialUSB.h
@@ -8,10 +8,9 @@
 
 #include <zephyrSerial.h>
 
-#if defined(CONFIG_USB_DEVICE_STACK_NEXT)
 #include <zephyr/usb/usbd.h>
+
 extern "C" struct usbd_context *usbd_init_device(usbd_msg_cb_t msg_cb);
-#endif
 
 namespace arduino {
 
@@ -44,12 +43,10 @@ protected:
 private:
 	bool started = false;
 
-#if defined(CONFIG_USB_DEVICE_STACK_NEXT)
 	struct usbd_context *_usbd;
 	int enable_usb_device_next();
 	static void usbd_next_cb(struct usbd_context *const ctx, const struct usbd_msg *msg);
 	static int usb_disable();
-#endif
 };
 } // namespace arduino
 

--- a/cores/arduino/SerialUSB.h
+++ b/cores/arduino/SerialUSB.h
@@ -8,6 +8,8 @@
 
 #include <zephyrSerial.h>
 
+#if ZARD_BOARD_HAS_SERIALUSB
+
 #include <zephyr/usb/usbd.h>
 
 extern "C" struct usbd_context *usbd_init_device(usbd_msg_cb_t msg_cb);
@@ -50,6 +52,10 @@ private:
 };
 } // namespace arduino
 
+extern arduino::SerialUSB_ SerialUSB;
+
 #if ZARD_FIRST_SERIAL_IS_SERIALUSB
 extern arduino::SerialUSB_ Serial;
 #endif
+
+#endif /* ZARD_BOARD_HAS_SERIALUSB */

--- a/cores/arduino/USB.cpp
+++ b/cores/arduino/USB.cpp
@@ -26,7 +26,6 @@ void arduino::SerialUSB_::baudChangeHandler(const struct device *dev, uint32_t r
 	}
 }
 
-#if defined(CONFIG_USB_DEVICE_STACK_NEXT)
 int arduino::SerialUSB_::usb_disable() {
 	// To avoid Cannot perform port reset: 1200-bps touch: setting DTR to OFF: protocol error
 	k_sleep(K_MSEC(100));
@@ -67,7 +66,6 @@ int arduino::SerialUSB_::enable_usb_device_next(void) {
 	}
 	return 0;
 }
-#endif /* defined(CONFIG_USB_DEVICE_STACK_NEXT) */
 
 void arduino::SerialUSB_::begin(unsigned long baudrate, uint16_t config) {
 	if (!started) {

--- a/cores/arduino/USB.cpp
+++ b/cores/arduino/USB.cpp
@@ -10,9 +10,8 @@
 #include <zephyr/usb/usb_device.h>
 #include <SerialUSB.h>
 
-#if ZARD_FIRST_SERIAL_IS_SERIALUSB
-const struct device *const usb_dev =
-	DEVICE_DT_GET(DT_PHANDLE_BY_IDX(DT_PATH(zephyr_user), cdc_acm_serial, 0));
+#if ZARD_BOARD_HAS_SERIALUSB
+const struct device *const usb_dev = DEVICE_DT_GET(ZARD_SERIALUSB_PHANDLE);
 
 void __attribute__((weak)) _on_1200_bps() {
 	NVIC_SystemReset();
@@ -29,7 +28,7 @@ void arduino::SerialUSB_::baudChangeHandler(const struct device *dev, uint32_t r
 int arduino::SerialUSB_::usb_disable() {
 	// To avoid Cannot perform port reset: 1200-bps touch: setting DTR to OFF: protocol error
 	k_sleep(K_MSEC(100));
-	return usbd_disable(Serial._usbd);
+	return usbd_disable(SerialUSB._usbd);
 }
 
 void arduino::SerialUSB_::usbd_next_cb(struct usbd_context *const ctx, const struct usbd_msg *msg) {
@@ -45,8 +44,8 @@ void arduino::SerialUSB_::usbd_next_cb(struct usbd_context *const ctx, const str
 
 	if (msg->type == USBD_MSG_CDC_ACM_LINE_CODING) {
 		uint32_t baudrate;
-		uart_line_ctrl_get(Serial.uart, UART_LINE_CTRL_BAUD_RATE, &baudrate);
-		Serial.baudChangeHandler(nullptr, baudrate);
+		uart_line_ctrl_get(SerialUSB.uart, UART_LINE_CTRL_BAUD_RATE, &baudrate);
+		SerialUSB.baudChangeHandler(nullptr, baudrate);
 	}
 }
 
@@ -90,18 +89,23 @@ arduino::SerialUSB_::operator bool() {
 }
 
 size_t arduino::SerialUSB_::write(const uint8_t *buffer, size_t size) {
-	if (!Serial) {
+	if (!SerialUSB) {
 		return 0;
 	}
 	return arduino::ZephyrSerial::write(buffer, size);
 }
 
 void arduino::SerialUSB_::flush() {
-	if (!Serial) {
+	if (!SerialUSB) {
 		return;
 	}
 	arduino::ZephyrSerial::flush();
 }
 
-arduino::SerialUSB_ Serial(usb_dev);
+arduino::SerialUSB_ SerialUSB(usb_dev);
+
+#if ZARD_FIRST_SERIAL_IS_SERIALUSB
+extern arduino::SerialUSB_ Serial [[gnu::alias("SerialUSB")]];
+#endif
+
 #endif

--- a/cores/arduino/main.cpp
+++ b/cores/arduino/main.cpp
@@ -24,8 +24,8 @@ void __attribute__((weak)) __loopHook(void) {
 }
 
 int main(void) {
-#if ZARD_FIRST_SERIAL_IS_SERIALUSB
-	Serial.begin(115200);
+#if ZARD_BOARD_HAS_SERIALUSB
+	SerialUSB.begin(115200);
 #endif
 
 	initVariant();

--- a/cores/arduino/zephyrSerial.h
+++ b/cores/arduino/zephyrSerial.h
@@ -130,7 +130,7 @@ protected:
 #if DT_NODE_HAS_PROP(DT_PATH(zephyr_user), cdc_acm_serial)
 /* Devicetree requires a SerialUSB object for 'Serial'. */
 #define ZARD_SKIP_FIRST_SERIAL 1
-#if (CONFIG_USB_CDC_ACM || CONFIG_USBD_CDC_ACM_CLASS)
+#if CONFIG_USBD_CDC_ACM_CLASS
 /* SerialUSB can be compiled in the project. */
 #define ZARD_FIRST_SERIAL_IS_SERIALUSB 1
 #else

--- a/cores/arduino/zephyrSerial.h
+++ b/cores/arduino/zephyrSerial.h
@@ -121,8 +121,17 @@ protected:
 #define ZARD_SERIAL_INDEXOF(node)                                                                  \
 	DT_FOREACH_PROP_ELEM_VARGS(DT_PATH(zephyr_user), serials, ZARD_SERIAL_MATCH, node)
 
+/* Get the name of the Serial object associated with a given node. If the node
+ * is not in the 'serials' array, then check if it is the SerialUSB node.
+ */
+#define ZARD_SERIAL_NAME_BY_NODE(node)                                                             \
+	COND_CODE_0(IS_EMPTY(ZARD_SERIAL_INDEXOF(node)),                                           \
+                    (ZARD_SERIAL_NAME(ZARD_SERIAL_INDEXOF(node))),			           \
+                    (COND_CODE_1(DT_SAME_NODE(node, ZARD_SERIALUSB_PHANDLE),                       \
+                                 (SerialUSB), (unkown Serial object))))
+
 /* Serial object associated with the Zephyr console. */
-#define ARDUINO_CONSOLE_SERIAL ZARD_SERIAL_NAME(ZARD_SERIAL_INDEXOF(DT_CHOSEN(zephyr_console)))
+#define ARDUINO_CONSOLE_SERIAL ZARD_SERIAL_NAME_BY_NODE(DT_CHOSEN(zephyr_console))
 
 /* Serial object associated with the first HW serial (usually on D0/D1). */
 #define ARDUINO_HARDWARE_SERIAL ZARD_SERIAL_NAME(0)
@@ -134,7 +143,7 @@ protected:
  */
 #define ZARD_FIRST_SERIAL_IS_ARDUINO_ROUTER 1
 #define ARDUINO_ROUTER_PHANDLE              DT_PROP(DT_PATH(zephyr_user), arduino_router_serial)
-#define ARDUINO_ROUTER_SERIAL               ZARD_SERIAL_NAME(ZARD_SERIAL_INDEXOF(ARDUINO_ROUTER_PHANDLE))
+#define ARDUINO_ROUTER_SERIAL               ZARD_SERIAL_NAME_BY_NODE(ARDUINO_ROUTER_PHANDLE)
 #endif
 
 #if DT_NODE_HAS_PROP(DT_PATH(zephyr_user), cdc_acm_serial)
@@ -142,9 +151,9 @@ protected:
 #if CONFIG_USBD_CDC_ACM_CLASS
 /* SerialUSB can be compiled in the project. */
 #define ZARD_BOARD_HAS_SERIALUSB 1
-#define SERIALUSB_PHANDLE DT_PROP(DT_PATH(zephyr_user), cdc_acm_serial)
+#define ZARD_SERIALUSB_PHANDLE   DT_PROP(DT_PATH(zephyr_user), cdc_acm_serial)
+/* Router takes precedence as 'Serial' when both are defined. */
 #if !ZARD_FIRST_SERIAL_IS_ARDUINO_ROUTER
-/* Router takes precedence when both are defined. */
 #define ZARD_FIRST_SERIAL_IS_SERIALUSB 1
 #endif
 #else

--- a/cores/arduino/zephyrSerial.h
+++ b/cores/arduino/zephyrSerial.h
@@ -127,14 +127,26 @@ protected:
 /* Serial object associated with the first HW serial (usually on D0/D1). */
 #define ARDUINO_HARDWARE_SERIAL ZARD_SERIAL_NAME(0)
 
+#if DT_NODE_HAS_PROP(DT_PATH(zephyr_user), arduino_router_serial)
+/* If the board has an arduino,router-serial node, and the currently used
+ * library has the support, then the 'Serial' object is actually the same as
+ * the Monitor object in the Arduino_RouterBridge library.
+ */
+#define ZARD_FIRST_SERIAL_IS_ARDUINO_ROUTER 1
+#define ARDUINO_ROUTER_PHANDLE              DT_PROP(DT_PATH(zephyr_user), arduino_router_serial)
+#define ARDUINO_ROUTER_SERIAL               ZARD_SERIAL_NAME(ZARD_SERIAL_INDEXOF(ARDUINO_ROUTER_PHANDLE))
+#endif
+
 #if DT_NODE_HAS_PROP(DT_PATH(zephyr_user), cdc_acm_serial)
 /* Devicetree requires a SerialUSB object for 'Serial'. */
-#define ZARD_SKIP_FIRST_SERIAL 1
 #if CONFIG_USBD_CDC_ACM_CLASS
 /* SerialUSB can be compiled in the project. */
 #define ZARD_BOARD_HAS_SERIALUSB 1
 #define SERIALUSB_PHANDLE DT_PROP(DT_PATH(zephyr_user), cdc_acm_serial)
+#if !ZARD_FIRST_SERIAL_IS_ARDUINO_ROUTER
+/* Router takes precedence when both are defined. */
 #define ZARD_FIRST_SERIAL_IS_SERIALUSB 1
+#endif
 #else
 /* SerialUSB is required but no driver was enabled for the USB CDC ACM device.
  * Define a stub Serial object to avoid build errors.
@@ -143,15 +155,10 @@ protected:
 #endif
 #endif
 
-#if DT_NODE_HAS_PROP(DT_PATH(zephyr_user), arduino_router_serial)
-/* If the board has an arduino,router-serial node, and the currently used
- * library has the support, then the 'Serial' object is actually the same as
- * the Monitor object in the Arduino_RouterBridge library.
- */
-#define ZARD_SKIP_FIRST_SERIAL              1
-#define ZARD_FIRST_SERIAL_IS_ARDUINO_ROUTER 1
-#define ARDUINO_ROUTER_PHANDLE              DT_PROP(DT_PATH(zephyr_user), arduino_router_serial)
-#define ARDUINO_ROUTER_SERIAL               ZARD_SERIAL_NAME(ZARD_SERIAL_INDEXOF(ARDUINO_ROUTER_PHANDLE))
+/* If one of the above groups match, they will define the first Serial object */
+#if ZARD_FIRST_SERIAL_IS_SERIALUSB || ZARD_FIRST_SERIAL_IS_ARDUINO_ROUTER ||                       \
+	ZARD_FIRST_SERIAL_IS_STUB
+#define ZARD_SKIP_FIRST_SERIAL 1
 #endif
 
 /* Name of a Serial object for a given index. */

--- a/cores/arduino/zephyrSerial.h
+++ b/cores/arduino/zephyrSerial.h
@@ -132,6 +132,8 @@ protected:
 #define ZARD_SKIP_FIRST_SERIAL 1
 #if CONFIG_USBD_CDC_ACM_CLASS
 /* SerialUSB can be compiled in the project. */
+#define ZARD_BOARD_HAS_SERIALUSB 1
+#define SERIALUSB_PHANDLE DT_PROP(DT_PATH(zephyr_user), cdc_acm_serial)
 #define ZARD_FIRST_SERIAL_IS_SERIALUSB 1
 #else
 /* SerialUSB is required but no driver was enabled for the USB CDC ACM device.

--- a/loader/llext_exports.c
+++ b/loader/llext_exports.c
@@ -150,11 +150,6 @@ EXPORT_SYMBOL(pinctrl_lookup_state);
 EXPORT_SYMBOL(pinctrl_configure_pins);
 #endif
 
-#if defined(CONFIG_USB_DEVICE_STACK)
-EXPORT_SYMBOL(usb_enable);
-EXPORT_SYMBOL(usb_disable);
-#endif
-
 #if CONFIG_LOG
 EXPORT_SYMBOL(z_log_msg_runtime_vcreate);
 FORCE_EXPORT_SYM(log_const_sketch)

--- a/loader/main.c
+++ b/loader/main.c
@@ -41,10 +41,11 @@ struct sketch_header_v1 {
 #define SKETCH_RAM_BUFFER_LEN 131072
 
 /* Need to replicate logic from zephyrSerial.h to avoid C++ here */
+#define ZARD_BOARD_HAS_SERIALUSB                                                                   \
+	DT_NODE_HAS_PROP(DT_PATH(zephyr_user), cdc_acm_serial) && CONFIG_USBD_CDC_ACM_CLASS
 #define ZARD_FIRST_SERIAL_IS_SERIALUSB                                                             \
-	DT_NODE_HAS_PROP(DT_PATH(zephyr_user), cdc_acm_serial) &&                                      \
-		CONFIG_USBD_CDC_ACM_CLASS &&                                       \
-		!(DT_NODE_HAS_PROP(DT_PATH(zephyr_user), arduino_router_serial))
+	ZARD_BOARD_HAS_SERIALUSB && !(DT_NODE_HAS_PROP(DT_PATH(zephyr_user), arduino_router_serial))
+
 #if ZARD_FIRST_SERIAL_IS_SERIALUSB
 const struct device *const usb_dev =
 	DEVICE_DT_GET(DT_PHANDLE_BY_IDX(DT_PATH(zephyr_user), cdc_acm_serial, 0));

--- a/loader/main.c
+++ b/loader/main.c
@@ -43,13 +43,12 @@ struct sketch_header_v1 {
 /* Need to replicate logic from zephyrSerial.h to avoid C++ here */
 #define ZARD_FIRST_SERIAL_IS_SERIALUSB                                                             \
 	DT_NODE_HAS_PROP(DT_PATH(zephyr_user), cdc_acm_serial) &&                                      \
-		(CONFIG_USB_CDC_ACM || CONFIG_USBD_CDC_ACM_CLASS) &&                                       \
+		CONFIG_USBD_CDC_ACM_CLASS &&                                       \
 		!(DT_NODE_HAS_PROP(DT_PATH(zephyr_user), arduino_router_serial))
 #if ZARD_FIRST_SERIAL_IS_SERIALUSB
 const struct device *const usb_dev =
 	DEVICE_DT_GET(DT_PHANDLE_BY_IDX(DT_PATH(zephyr_user), cdc_acm_serial, 0));
 
-#if CONFIG_USB_DEVICE_STACK_NEXT
 #include <zephyr/usb/usbd.h>
 struct usbd_context *usbd_init_device(usbd_msg_cb_t msg_cb);
 static struct usbd_context *_usbd = NULL;
@@ -88,7 +87,6 @@ int loader_usb_enable(void) {
 	}
 	return 0;
 }
-#endif
 
 #if CONFIG_SHELL
 static int enable_shell_usb(void) {


### PR DESCRIPTION
Currently zephyrSerial macros do DT-node-to-Arduino-object lookups only on generic `Serial` objects. Most importantly, this excludes `SerialUSB`, which is important for the Zephyr console and for some Arduino Router configurations.

This PR introduces `ZARD_SERIAL_NAME_BY_NODE` which performs a more exhaustive search and use that for the above situations.