### PR TITLE
extra: scripts: improving bootstrap.sh and venv usage

### DIFF
--- a/extra/bootstrap.sh
+++ b/extra/bootstrap.sh
@@ -14,8 +14,8 @@ log_msg() {
 	fi
 }
 
-if [ ! -f platform.txt ]; then
-  echo Launch this script from the root core folder as ./extra/bootstrap.sh
+if [ ! -f boards.txt ]; then
+  echo "Launch this script from the root core folder as ./extra/bootstrap.sh"
   exit 2
 fi
 
@@ -39,58 +39,141 @@ if [ -n "$WEST_CACHE" ]; then
   WEST_MODULES_CACHE="--auto-cache $WEST_CACHE/modules"
 fi
 
+PYTHON_VENV_PATH=${PYTHON_VENV_PATH:-"./venv"}
+
 get_unique_field_values() {
   local field="$1"
   local file="$2"
-  grep "$field=" $file | cut -d '=' -f 2 | xargs -n 1 echo | sort -u | xargs echo
+  grep "$field=" "$file" | cut -d '=' -f 2 | xargs -n 1 echo | sort -u | xargs echo
 }
 
-NEEDED_HALS=$(get_unique_field_values 'build.zephyr_hals' boards.txt)
-NEEDED_TOOLCHAINS=$(get_unique_field_values 'build.zephyr_toolchain' boards.txt)
+get_hals() {
+  get_unique_field_values 'build.zephyr_hals' boards.txt
+}
 
-HAL_FILTER="-hal_.*"
-for hal in $NEEDED_HALS; do
-  HAL_FILTER="$HAL_FILTER,+$hal"
-done
+get_toolchains() {
+  get_unique_field_values 'build.zephyr_toolchain' boards.txt
+}
 
-log_msg "group" "Bootstrapping Python environment for Zephyr"
-PYTHON_VENV_PATH=${PYTHON_VENV_PATH:-"./venv"}
-python3 -m venv ${PYTHON_VENV_PATH}
-source venv/bin/activate
-[[ -z "${DISABLE_VENV:-}" ]] && { source ${PYTHON_VENV_PATH}/bin/activate; }
-pip3 install west protobuf grpcio-tools
-log_msg "endgroup"
+# --- Subcommands ---
 
-if ! [ -d ../.west ] ; then
-  log_msg "group" "Initializing Zephyr workspace and modules: $HAL_FILTER"
-  west init -l .
-else
-  log_msg "warning" "Zephyr workspace already initialized, skipping west init"
-  log_msg "group" "Refreshing workspace and modules: $HAL_FILTER"
-fi
-west config manifest.project-filter -- "$HAL_FILTER"
-west update $WEST_MODULES_CACHE "$@"
-west zephyr-export
-pip3 install -r ../zephyr/scripts/requirements-base.txt
-log_msg "endgroup"
-
-TOOLCHAIN_VERSIONS=$(for tc in $NEEDED_TOOLCHAINS; do
-  version=$(jq -r --arg name "$tc" '.toolsDependencies[] | select(.name == $name) | .version' extra/artifacts/_common.json)
-  if [ -z "$version" ]; then
-    echo "No version found for toolchain '$tc' in extra/artifacts/_common.json" >&2
-    exit 1
-  fi
-  echo "$version $tc"
-done | sort -V)
-
-for version in $(echo "$TOOLCHAIN_VERSIONS" | cut -d ' ' -f 1 | sort -u -V); do
-  toolchains=$(echo "$TOOLCHAIN_VERSIONS" | awk -v v="$version" '$1 == v { print $2 }')
-  log_msg "group" "Installing Zephyr SDK ${version}: ${toolchains}"
-  west sdk install --version "$version" -t $toolchains
+setup_venv() {
+  log_msg "group" "Bootstrapping Python environment for Zephyr"
+  python3 -m venv venv
+  [[ -z "${DISABLE_VENV:-}" ]] && { source ${PYTHON_VENV_PATH}/bin/activate; }
+  pip3 install west protobuf grpcio-tools
   log_msg "endgroup"
-done
+}
 
-NEEDED_HALS="arduino-api $NEEDED_HALS"
-log_msg "group" "Fetching blobs for: $NEEDED_HALS"
-west blobs $WEST_BLOBS_CACHE fetch $NEEDED_HALS
-log_msg "endgroup"
+west_init() {
+  local NEEDED_HALS
+  NEEDED_HALS=$(get_hals)
+
+  local HAL_FILTER="-hal_.*"
+  for hal in $NEEDED_HALS; do
+    HAL_FILTER="$HAL_FILTER,+$hal"
+  done
+
+  if ! [ -d ../.west ] ; then
+    west init -l . "$@"
+  else
+    log_msg "warning" "Zephyr workspace already initialized, skipping west init"
+  fi
+  west config manifest.project-filter -- "$HAL_FILTER"
+  log_msg "endgroup"
+}
+
+west_update() {
+  log_msg "group" "Initializing Zephyr modules"
+
+  west update $WEST_MODULES_CACHE "$@"
+  west zephyr-export
+  pip3 install -r ../zephyr/scripts/requirements-base.txt
+  log_msg "endgroup"
+}
+
+install_sdk() {
+  local NEEDED_TOOLCHAINS
+  NEEDED_TOOLCHAINS=$(get_toolchains)
+
+  local TOOLCHAIN_VERSIONS
+  TOOLCHAIN_VERSIONS=$(for tc in $NEEDED_TOOLCHAINS; do
+    version=$(jq -r --arg name "$tc" '.toolsDependencies[] | select(.name == $name) | .version' extra/artifacts/_common.json)
+    if [ -z "$version" ]; then
+      echo "No version found for toolchain '$tc' in extra/artifacts/_common.json" >&2
+      exit 1
+    fi
+    echo "$version $tc"
+  done | sort -V)
+
+  for version in $(echo "$TOOLCHAIN_VERSIONS" | cut -d ' ' -f 1 | sort -u -V); do
+    toolchains=$(echo "$TOOLCHAIN_VERSIONS" | awk -v v="$version" '$1 == v { print $2 }')
+    log_msg "group" "Installing Zephyr SDK ${version}: ${toolchains}"
+    west sdk install "$@" --version "$version" -t $toolchains
+    log_msg "endgroup"
+  done
+}
+
+fetch_blobs() {
+  local NEEDED_HALS
+  NEEDED_HALS="arduino-api $(get_hals)"
+  log_msg "group" "Fetching blobs for: $NEEDED_HALS"
+  west blobs fetch $WEST_BLOBS_CACHE "$@" $NEEDED_HALS
+  log_msg "endgroup"
+}
+
+all() {
+  setup_venv
+  west_init
+  west_update $@
+  install_sdk
+  fetch_blobs
+}
+
+show_usage() {
+  echo "Usage: $0 [command] [args...]"
+  echo ""
+  echo "Available commands:"
+  echo "  venv         Bootstrap Python venv and basic dependencies"
+  echo "  west_init    Initialize West workspace"
+  echo "  west_update  Update West workspace and dependencies"
+  echo "  sdk          Install required Zephyr SDKs"
+  echo "  blobs        Fetch required HAL blobs"
+  echo "  all          Execute all commands sequentially (default)"
+}
+
+# --- Main Dispatcher ---
+
+SUBCOMMAND="${1:-all}"
+
+case "$SUBCOMMAND" in
+  venv)
+    setup_venv
+    ;;
+  west_init)
+    shift
+    west_init "$@"
+    ;;
+  west_update)
+    shift
+    west_update "$@"
+    ;;
+  sdk)
+    shift
+    install_sdk "$@"
+    ;;
+  blobs)
+    shift
+    fetch_blobs "$@"
+    ;;
+  all)
+    shift
+    all $@
+    ;;
+  -h|--help|help)
+    show_usage
+    ;;
+  *)
+    all $@
+    ;;
+esac

--- a/extra/bootstrap.sh
+++ b/extra/bootstrap.sh
@@ -54,8 +54,10 @@ for hal in $NEEDED_HALS; do
 done
 
 log_msg "group" "Bootstrapping Python environment for Zephyr"
-python3 -m venv venv
+PYTHON_VENV_PATH=${PYTHON_VENV_PATH:-"./venv"}
+python3 -m venv ${PYTHON_VENV_PATH}
 source venv/bin/activate
+[[ -z "${DISABLE_VENV:-}" ]] && { source ${PYTHON_VENV_PATH}/bin/activate; }
 pip3 install west protobuf grpcio-tools
 log_msg "endgroup"
 

--- a/extra/build.sh
+++ b/extra/build.sh
@@ -5,9 +5,10 @@
 
 set -e
 
-source venv/bin/activate
+PYTHON_VENV_PATH=${PYTHON_VENV_PATH:-"./venv"}
+[[ -z "${DISABLE_VENV:-}" ]] && { source ${PYTHON_VENV_PATH}/bin/activate; }
 
-ZEPHYR_BASE=$(west topdir)/zephyr
+ZEPHYR_BASE=${ZEPHYR_BASE:-"$(west topdir)/zephyr"}
 
 if [ x$ZEPHYR_SDK_INSTALL_DIR == x"" ]; then
 	SDK_PATH=$(west sdk list | grep path | tail -n 1 | cut -d ':' -f 2 | tr -d ' ')

--- a/extra/get_variant_name.sh
+++ b/extra/get_variant_name.sh
@@ -5,7 +5,8 @@
 
 set -e
 
-source venv/bin/activate
+PYTHON_VENV_PATH=${PYTHON_VENV_PATH:-"./venv"}
+[[ -z "${DISABLE_VENV:-}" ]] && { source ${PYTHON_VENV_PATH}/bin/activate; }
 
 # Get the variant name (NORMALIZED_BOARD_TARGET in Zephyr)
 variant=$(cmake "-DBOARD=$1" -P extra/get_variant_name.cmake 2>/dev/null | grep 'VARIANT=' | cut -d '=' -f 2)


### PR DESCRIPTION
Adding the possiblity toi specify Python venv location through `PYTHON_VENV_PATH` and to disable the usage of venv by defining `DISABLE_VENV`.

Splitting `extra/bootstrap.sh` in subcommands, so that single steps of the bootstrap process can be executed, without parameters bootstrap.sh behaves like before.