### PR TITLE
extra/build.sh: Fix macOS build.

### DIFF
--- a/extra/build.sh
+++ b/extra/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright (c) Arduino s.r.l. and/or its affiliated companies
 # SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
The script uses mapfile, a bash 4+ builtin, macOS ships with old 3.x bash at /bin/bash.
Remove hardcoded #!/bin/bash and resolve bash via env so the script picks up the bash the user actually has (in homebrew) instead of the system one.


NOTE: The script has other command flags that are Not portable, my path just happens to mask them, so this will probably still fail on a vanilla install. This broke because CI doesn't seem to build on macos, even though docs say it's supported. I suggest adding a target to workflow, just a bare minimum build check.