### PR TITLE
misc: export k_work cancel APIs and ignore generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 /boards.local.txt
 /platform.local.txt
 /loader/VERSION
+/cores/arduino/api/
+
+__pycache__/
 
 llext-edk/
 cflags.txt

--- a/cores/arduino/main.cpp
+++ b/cores/arduino/main.cpp
@@ -15,11 +15,11 @@
 void start_static_threads();
 #endif
 
-// This function will be overwriten by most variants.
+// This function will be overwritten by most variants.
 void __attribute__((weak)) initVariant(void) {
 }
 
-// This function can be overwriten by one library.
+// This function can be overwritten by one library.
 void __attribute__((weak)) __loopHook(void) {
 }
 

--- a/loader/llext_exports.c
+++ b/loader/llext_exports.c
@@ -333,6 +333,8 @@ EXPORT_SYMBOL(k_work_schedule_for_queue);
 EXPORT_SYMBOL(k_work_reschedule_for_queue);
 EXPORT_SYMBOL(k_work_queue_start);
 EXPORT_SYMBOL(k_work_submit_to_queue);
+EXPORT_SYMBOL(k_work_cancel);
+EXPORT_SYMBOL(k_work_cancel_delayable);
 // FORCE_EXPORT_SYM(k_timer_user_data_set);
 // FORCE_EXPORT_SYM(k_timer_start);
 

--- a/tools/gen-rodata-ld/.gitignore
+++ b/tools/gen-rodata-ld/.gitignore
@@ -1,0 +1,1 @@
+gen-rodata-ld

--- a/zephyr/blobs/ArduinoCore-API/.gitignore
+++ b/zephyr/blobs/ArduinoCore-API/.gitignore
@@ -1,1 +1,2 @@
 *.tar.gz
+ArduinoCore-API-*/


### PR DESCRIPTION
- `k_work_cancel()` and `k_work_cancel_delayable()` functions are added to loader app.
- New .gitignore files to ignore generated files.
- Fix typo in main.cpp.