### PR TITLE
Arduino_LED_Matrix: add missing include guard

### DIFF
--- a/libraries/Arduino_LED_Matrix/src/Arduino_LED_Matrix.h
+++ b/libraries/Arduino_LED_Matrix/src/Arduino_LED_Matrix.h
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#pragma once
+
 #include <Arduino.h>
 #include <cmsis_core.h>
 


### PR DESCRIPTION
## Description

Add `#pragma once` to `Arduino_LED_Matrix.h`.

Without an include guard, including the header more than once in the same
translation unit causes redefinition errors for `reverse(uint32_t)` and
`Arduino_LED_Matrix`.

Fixes #617

## Testing

Verified with the following minimal sketch:

```cpp
#include <Arduino_LED_Matrix.h>
#include <Arduino_LED_Matrix.h>

void setup() {}
void loop() {}
```