### PR TITLE
Ethernet: linkStatus: check for carrier

### DIFF
--- a/libraries/Ethernet/src/Ethernet.cpp
+++ b/libraries/Ethernet/src/Ethernet.cpp
@@ -78,12 +78,12 @@ int EthernetClass::begin(uint8_t *mac, IPAddress ip, IPAddress dns, IPAddress ga
 }
 
 EthernetLinkStatus EthernetClass::linkStatus() {
-	if (hardwareStatus() == EthernetOk) {
-		if (net_if_is_up(netif)) {
-			return LinkON;
-		} else {
-			return LinkOFF;
-		}
+	if (hardwareStatus() != EthernetOk) {
+		return LinkOFF;
+	}
+
+	if (net_if_is_carrier_ok(netif)) {
+		return LinkON;
 	}
 
 	return LinkOFF;
@@ -115,10 +115,6 @@ EthernetHardwareStatus EthernetClass::hardwareStatus() {
 		if (ret < 0) {
 			return EthernetNoHardware;
 		}
-	}
-
-	if (!net_if_is_up(netif)) {
-		net_if_up(netif);
 	}
 
 	return EthernetOk;


### PR DESCRIPTION
In link status method  instead of looking if the netif was brought up by net_if_up() check if the carrier is connected. Some boards may require time to set the net if into admin state. Furthermore the admin state should be set by the begin function instead